### PR TITLE
[Language Support] Turkish layout added 

### DIFF
--- a/java/res/values/donottranslate.xml
+++ b/java/res/values/donottranslate.xml
@@ -121,5 +121,7 @@
         <item>nordic</item>
         <item>tr:AsciiCapable,SupportTouchPositionCorrection,EmojiCapable</item>
         <item>qwerty</item>
+        <item>tr:AsciiCapable,SupportTouchPositionCorrection,EmojiCapable</item>
+        <item>turkish</item>
     </string-array>
 </resources>

--- a/java/res/xml/kdb_turkish.xml
+++ b/java/res/xml/kdb_turkish.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+/*
+**
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<Keyboard xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <include latin:keyboardLayout="@xml/rows_turkish" />
+</Keyboard>

--- a/java/res/xml/keyboard_layout_set_turkish.xml
+++ b/java/res/xml/keyboard_layout_set_turkish.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<KeyboardLayoutSet
+    xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <Element
+        latin:elementName="alphabet"
+        latin:elementKeyboard="@xml/kdb_turkish"
+        latin:enableProximityCharsCorrection="true" />
+    <Element
+        latin:elementName="symbols"
+        latin:elementKeyboard="@xml/kbd_symbols" />
+    <Element
+        latin:elementName="symbolsShifted"
+        latin:elementKeyboard="@xml/kbd_symbols_shift" />
+    <Element
+        latin:elementName="phone"
+        latin:elementKeyboard="@xml/kbd_phone" />
+    <Element
+        latin:elementName="phoneSymbols"
+        latin:elementKeyboard="@xml/kbd_phone_symbols" />
+    <Element
+        latin:elementName="number"
+        latin:elementKeyboard="@xml/kbd_number" />
+</KeyboardLayoutSet>

--- a/java/res/xml/rowkeys_turkish1.xml
+++ b/java/res/xml/rowkeys_turkish1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2014, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Key
+        latin:keySpec="!text/keyspec_q"
+        latin:moreKeys="!text/morekeys_q,!text/qwertysyms_q,!text/number_1,!text/actions_q" />
+    <Key
+        latin:keySpec="!text/keyspec_w"
+        latin:moreKeys="!text/morekeys_w,!text/qwertysyms_w,!text/number_2,!text/actions_w" />
+    <Key
+        latin:keySpec="e"
+        latin:moreKeys="!text/morekeys_e,!text/morekeys_misc_e,!text/qwertysyms_e,!text/number_3,!text/actions_e" />
+    <Key
+        latin:keySpec="r"
+        latin:moreKeys="!text/morekeys_r,!text/qwertysyms_r,!text/number_4,!text/actions_r" />
+    <Key
+        latin:keySpec="t"
+        latin:moreKeys="!text/morekeys_t,!text/qwertysyms_t,!text/number_5,!text/actions_t" />
+    <Key
+        latin:keySpec="!text/keyspec_y"
+        latin:moreKeys="!text/morekeys_y,!text/qwertysyms_y,!text/number_6,!text/actions_y" />
+    <Key
+        latin:keySpec="u"
+        latin:moreKeys="!text/morekeys_u,!text/morekeys_misc_u,!text/qwertysyms_u,!text/number_7,!text/actions_u" />
+
+    <!-- U+0131: "ı" LATIN SMALL LETTER DOTLESS I -->
+    <Key
+        latin:keySpec="&#x0131;"
+        latin:moreKeys="!text/morekeys_i,!text/morekeys_misc_i,!text/qwertysyms_i,!text/number_8,!text/actions_i" />
+    <Key
+        latin:keySpec="o"
+        latin:moreKeys="!text/morekeys_o,!text/morekeys_misc_o,!text/qwertysyms_o,!text/number_9,!text/actions_o" />
+    <Key
+        latin:keySpec="p"
+        latin:moreKeys="!text/morekeys_p,!text/qwertysyms_p,!text/number_0,!text/actions_p" />
+
+    <!-- U+011F: "ğ" LATIN SMALL LETTER G WITH BREVE
+         U+0123: "ģ" LATIN SMALL LETTER G WITH CEDILLA -->
+    <Key
+        latin:keySpec="&#x011F;"
+        latin:keyHintLabel="&#x0123;"
+        latin:additionalMoreKeys="!text/morekeys_g" />
+
+    <!-- U+00FC: "ü" LATIN SMALL LETTER U WITH DIAERESIS
+         U+00FA: "ú" LATIN SMALL LETTER U WITH ACUTE-->
+    <Key
+        latin:keySpec="&#x00FC;"
+        latin:keyHintLabel="&#x00FA;"
+        latin:moreKeys="!text/morekeys_u" />
+</merge>

--- a/java/res/xml/rowkeys_turkish2.xml
+++ b/java/res/xml/rowkeys_turkish2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwerty2" />
+
+    <!-- U+015F: "ş" LATIN SMALL LETTER S WITH CEDILLA
+         U+015B: "ś" LATIN SMALL LETTER S WITH ACUTE-->
+    <Key
+        latin:keySpec="&#x015F;"
+        latin:keyHintLabel="&#x015B;"
+        latin:moreKeys="!text/morekeys_s" />
+
+    <!-- U+00ED: "í" LATIN SMALL LETTER I WITH ACUTE -->
+    <Key
+        latin:keySpec="i"
+        latin:keyHintLabel="&#x00ED;"
+        latin:additionalMoreKeys="!text/morekeys_i" />
+</merge>

--- a/java/res/xml/rowkeys_turkish3.xml
+++ b/java/res/xml/rowkeys_turkish3.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2012, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<merge xmlns:latin="http://schemas.android.com/apk/res-auto">
+    <include
+        latin:keyboardLayout="@xml/rowkeys_qwerty3" />
+
+    <!-- U+00F6: "ö" LATIN SMALL LETTER O WITH DIAERESIS
+         U+00F3: "ó" LATIN SMALL LETTER O WITH ACUTE -->
+    <Key
+        latin:keySpec="&#x00F6;"
+        latin:keyHintLabel="&#x00F3;"
+        latin:moreKeys="!text/morekeys_o" />
+
+    <!-- U+00E7: "ç" LATIN SMALL LETTER C WITH CEDILLA
+         U+0107: "ć" LATIN SMALL LETTER C WITH ACUTE -->
+    <Key
+        latin:keySpec="&#x00E7;"
+        latin:keyHintLabel="&#x0107;"
+        latin:additionalMoreKeys="!text/morekeys_c" />
+</merge>

--- a/java/res/xml/rows_turkish.xml
+++ b/java/res/xml/rows_turkish.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <include
+        latin:keyboardLayout="@xml/key_styles_common" />
+    <include latin:keyboardLayout="@xml/row_number_switch" />
+    <Row
+        latin:keyWidth="8.333%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_turkish1" />
+    </Row>
+    <Row
+        latin:keyWidth="8.333%p"
+    >
+        <include
+            latin:keyboardLayout="@xml/rowkeys_turkish2"
+            latin:keyXPos="4.167%p" />
+    </Row>
+    <Row
+        latin:keyWidth="8.333%p"
+    >
+        <Key
+            latin:keyStyle="shiftKeyStyle"
+            latin:keyWidth="12.5%p"
+            latin:visualInsetsRight="1%p" />
+        <include
+            latin:keyboardLayout="@xml/rowkeys_turkish3" />
+        <Key
+            latin:keyStyle="deleteKeyStyle"
+            latin:keyWidth="fillRight"
+            latin:visualInsetsLeft="1%p" />
+    </Row>
+    <include
+        latin:keyboardLayout="@xml/row_qwerty4" />
+</merge>

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/AddLanguage.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/AddLanguage.kt
@@ -108,7 +108,7 @@ val LocaleLayoutMap = mapOf(
     "te_IN"  to   listOf("telugu"),
     "th"     to   listOf("thai"),
     "tl"     to   makeQwertyWithPrimary("spanish"),
-    "tr"     to   QwertyVariants,
+    "tr"     to   makeQwertyWithPrimary("turkish"),
     "uk"     to   listOf("east_slavic", "east_slavic_phonetic"),
     "uz_UZ"  to   listOf("uzbek"),
     "vi"     to   QwertyVariants,

--- a/tools/make-keyboard-text/res/values-tr/donottranslate-more-keys.xml
+++ b/tools/make-keyboard-text/res/values-tr/donottranslate-more-keys.xml
@@ -25,13 +25,14 @@
     <!-- U+0259: "ə" LATIN SMALL LETTER SCHWA
          U+00E9: "é" LATIN SMALL LETTER E WITH ACUTE -->
     <string name="morekeys_e">&#x0259;,&#x00E9;</string>
-    <!-- U+00EE: "î" LATIN SMALL LETTER I WITH CIRCUMFLEX
+    <!-- U+0131: "ı" LATIN SMALL LETTER DOTLESS I
+         U+00EE: "î" LATIN SMALL LETTER I WITH CIRCUMFLEX
          U+00EF: "ï" LATIN SMALL LETTER I WITH DIAERESIS
          U+00EC: "ì" LATIN SMALL LETTER I WITH GRAVE
          U+00ED: "í" LATIN SMALL LETTER I WITH ACUTE
          U+012F: "į" LATIN SMALL LETTER I WITH OGONEK
          U+012B: "ī" LATIN SMALL LETTER I WITH MACRON -->
-    <string name="morekeys_i">&#x00EE;,&#x00EF;,&#x00EC;,&#x00ED;,&#x012F;,&#x012B;</string>
+    <string name="morekeys_i">&#x0131;,&#x00EE;,&#x00EF;,&#x00EC;,&#x00ED;,&#x012F;,&#x012B;</string>
     <!-- U+00F6: "ö" LATIN SMALL LETTER O WITH DIAERESIS
          U+00F4: "ô" LATIN SMALL LETTER O WITH CIRCUMFLEX
          U+0153: "œ" LATIN SMALL LIGATURE OE

--- a/tools/make-keyboard-text/res/values-tr/donottranslate-more-keys.xml
+++ b/tools/make-keyboard-text/res/values-tr/donottranslate-more-keys.xml
@@ -25,14 +25,13 @@
     <!-- U+0259: "ə" LATIN SMALL LETTER SCHWA
          U+00E9: "é" LATIN SMALL LETTER E WITH ACUTE -->
     <string name="morekeys_e">&#x0259;,&#x00E9;</string>
-    <!-- U+0131: "ı" LATIN SMALL LETTER DOTLESS I
-         U+00EE: "î" LATIN SMALL LETTER I WITH CIRCUMFLEX
+    <!-- U+00EE: "î" LATIN SMALL LETTER I WITH CIRCUMFLEX
          U+00EF: "ï" LATIN SMALL LETTER I WITH DIAERESIS
          U+00EC: "ì" LATIN SMALL LETTER I WITH GRAVE
          U+00ED: "í" LATIN SMALL LETTER I WITH ACUTE
          U+012F: "į" LATIN SMALL LETTER I WITH OGONEK
          U+012B: "ī" LATIN SMALL LETTER I WITH MACRON -->
-    <string name="morekeys_i">&#x0131;,&#x00EE;,&#x00EF;,&#x00EC;,&#x00ED;,&#x012F;,&#x012B;</string>
+    <string name="morekeys_i">&#x00EE;,&#x00EF;,&#x00EC;,&#x00ED;,&#x012F;,&#x012B;</string>
     <!-- U+00F6: "ö" LATIN SMALL LETTER O WITH DIAERESIS
          U+00F4: "ô" LATIN SMALL LETTER O WITH CIRCUMFLEX
          U+0153: "œ" LATIN SMALL LIGATURE OE


### PR DESCRIPTION
Adds Turkish characters in addition to qwerty layout.

I have added the keys but unable to determine which characters to pop up when long pressed to new characters.

New layout:
![image](https://github.com/futo-org/android-keyboard/assets/20776588/7f6f803c-9eec-4fe9-8a27-1b529d2f3dd4)

New layout with number line and hints enabled:
![image](https://github.com/futo-org/android-keyboard/assets/20776588/097beb3d-bcae-423b-aa99-3f1a440cfc9f)
