### PR TITLE
Layouts: east_slavic layout update

### DIFF
--- a/java/res/xml/rowkeys_east_slavic2.xml
+++ b/java/res/xml/rowkeys_east_slavic2.xml
@@ -23,37 +23,50 @@
 >
     <!-- U+0444: "ф" CYRILLIC SMALL LETTER EF -->
     <Key
-        latin:keySpec="&#x0444;" />
+        latin:keySpec="&#x0444;"
+	latin:moreKeys="!text/morekeys_a,!text/qwertysyms_a" />
     <Key
         latin:keySpec="!text/keyspec_east_slavic_row2_2"
-        latin:moreKeys="!text/morekeys_east_slavic_row2_2" />
+        latin:moreKeys="!text/morekeys_east_slavic_row2_2,!text/morekeys_s,!text/qwertysyms_s" />
     <!-- U+0432: "в" CYRILLIC SMALL LETTER VE -->
     <Key
-        latin:keySpec="&#x0432;" />
+        latin:keySpec="&#x0432;"
+        latin:keyHintLabel="₽"
+        latin:additionalMoreKeys="₽" />
     <!-- U+0430: "а" CYRILLIC SMALL LETTER A -->
     <Key
         latin:keySpec="&#x0430;"
-        latin:moreKeys="!text/morekeys_cyrillic_a" />
+        latin:moreKeys="!text/morekeys_cyrillic_a"
+        latin:keyHintLabel="_"
+        latin:additionalMoreKeys="_" />
     <!-- U+043F: "п" CYRILLIC SMALL LETTER PE -->
     <Key
-        latin:keySpec="&#x043F;" />
+        latin:keySpec="&#x043F;"
+        latin:moreKeys="!text/morekeys_d,!text/qwertysyms_d" />
     <!-- U+0440: "р" CYRILLIC SMALL LETTER ER -->
     <Key
-        latin:keySpec="&#x0440;" />
+        latin:keySpec="&#x0440;"
+        latin:moreKeys="!text/morekeys_h,!text/qwertysyms_h" />
     <!-- U+043E: "о" CYRILLIC SMALL LETTER O -->
     <Key
         latin:keySpec="&#x043E;"
-        latin:moreKeys="!text/morekeys_cyrillic_o" />
+        latin:moreKeys="!text/morekeys_cyrillic_o,!text/morekeys_j,!text/qwertysyms_j" />
     <!-- U+043B: "л" CYRILLIC SMALL LETTER EL -->
     <Key
-        latin:keySpec="&#x043B;" />
+        latin:keySpec="&#x043B;"
+        latin:moreKeys="!text/morekeys_k,!text/qwertysyms_k" />
     <!-- U+0434: "д" CYRILLIC SMALL LETTER DE -->
     <Key
-        latin:keySpec="&#x0434;" />
+        latin:keySpec="&#x0434;"
+        latin:moreKeys="!text/morekeys_l,!text/qwertysyms_l" />
     <!-- U+0436: "ж" CYRILLIC SMALL LETTER ZHE -->
     <Key
-        latin:keySpec="&#x0436;" />
+        latin:keySpec="&#x0436;"
+        latin:keyHintLabel="/"
+        latin:additionalMoreKeys="/" />
     <Key
         latin:keySpec="!text/keyspec_east_slavic_row2_11"
-        latin:moreKeys="!text/morekeys_east_slavic_row2_11" />
+        latin:moreKeys="!text/morekeys_east_slavic_row2_11"
+        latin:keyHintLabel="~"
+        latin:additionalMoreKeys="~" />
 </merge>

--- a/java/res/xml/rowkeys_east_slavic3.xml
+++ b/java/res/xml/rowkeys_east_slavic3.xml
@@ -23,29 +23,39 @@
 >
     <!-- U+044F: "я" CYRILLIC SMALL LETTER YA -->
     <Key
-        latin:keySpec="&#x044F;" />
+        latin:keySpec="&#x044F;"
+        latin:moreKeys="!text/morekeys_z,!text/qwertysyms_z" />
     <!-- U+0447: "ч" CYRILLIC SMALL LETTER CHE -->
     <Key
-        latin:keySpec="&#x0447;" />
+        latin:keySpec="&#x0447;"
+        latin:moreKeys="!text/morekeys_x,!text/qwertysyms_x" />
     <!-- U+0441: "с" CYRILLIC SMALL LETTER ES -->
     <Key
-        latin:keySpec="&#x0441;" />
+        latin:keySpec="&#x0441;"
+        latin:moreKeys="!text/morekeys_c,!text/qwertysyms_c" />
     <!-- U+043C: "м" CYRILLIC SMALL LETTER EM -->
     <Key
-        latin:keySpec="&#x043C;" />
+        latin:keySpec="&#x043C;"
+        latin:moreKeys="!text/morekeys_v,!text/qwertysyms_v" />
     <Key
-        latin:keySpec="!text/keyspec_east_slavic_row3_5" />
+        latin:keySpec="!text/keyspec_east_slavic_row3_5"
+        latin:moreKeys="!text/morekeys_b,!text/qwertysyms_b" />
     <!-- U+0442: "т" CYRILLIC SMALL LETTER TE -->
     <Key
-        latin:keySpec="&#x0442;" />
+        latin:keySpec="&#x0442;"
+        latin:moreKeys="!text/morekeys_n,!text/qwertysyms_n" />
     <!-- U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN -->
     <Key
         latin:keySpec="&#x044C;"
-        latin:moreKeys="!text/morekeys_cyrillic_soft_sign" />
+        latin:moreKeys="!text/morekeys_cyrillic_soft_sign,!text/morekeys_m,!text/qwertysyms_m" />
     <!-- U+0431: "б" CYRILLIC SMALL LETTER BE -->
     <Key
-        latin:keySpec="&#x0431;" />
+        latin:keySpec="&#x0431;"
+        latin:keyHintLabel="\\"
+        latin:additionalMoreKeys="\\" />
     <!-- U+044E: "ю" CYRILLIC SMALL LETTER YU -->
     <Key
-        latin:keySpec="&#x044E;" />
+        latin:keySpec="&#x044E;"
+        latin:keyHintLabel="%"
+        latin:additionalMoreKeys="%" />
 </merge>


### PR DESCRIPTION
Add additional long-press symbols, linked from QWERTY layout as well as additional symbols sprinkled from GBoard layout.
I'm aware of backslash not showing up as hint, but unfortunately I'm not really much into Java, so that I can't help with.
