### PR TITLE
Adding missing keys for Bépo (french) layout

### DIFF
--- a/java/res/xml/row_bepo4.xml
+++ b/java/res/xml/row_bepo4.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2010, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<merge
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
+>
+    <Row
+        latin:keyWidth="10%p"
+    >
+        <Key
+            latin:keyStyle="toSymbolKeyStyle"
+            latin:keyWidth="10%p" />
+        <include
+            latin:keyboardLayout="@xml/key_comma"
+            latin:moreKeys=";" />
+        <Key
+            latin:keySpec="'"/>
+        <include
+            latin:keyXPos="30%p"
+            latin:keyboardLayout="@xml/key_space_5kw" />
+        <include
+            latin:keyboardLayout="@xml/key_period" />
+        <Key
+            latin:keyStyle="enterKeyStyle"
+            latin:keyWidth="fillRight" />
+    </Row>
+</merge>

--- a/java/res/xml/rowkeys_bepo1.xml
+++ b/java/res/xml/rowkeys_bepo1.xml
@@ -21,7 +21,7 @@
         latin:moreKeys="!text/number_1,!text/qwertysyms_q,!text/morekeys_b" />
     <Key
         latin:keySpec="&#xE9;"
-        latin:moreKeys="!text/number_2,!text/qwertysyms_w,&#xE8;" />
+        latin:moreKeys="!text/number_2,!text/qwertysyms_w" />
     <Key
         latin:keySpec="p"
         latin:moreKeys="!text/number_3,!text/qwertysyms_e,!text/morekeys_p" />
@@ -29,21 +29,23 @@
         latin:keySpec="o"
         latin:moreKeys="!text/number_4,!text/qwertysyms_r,!text/morekeys_o" />
     <Key
-        latin:keySpec="v"
+        latin:keySpec="&#xE8;"
         latin:moreKeys="!text/number_5,!text/qwertysyms_t,!text/morekeys_v" />
     <Key
-        latin:keySpec="d"
+        latin:keySpec="v"
         latin:moreKeys="!text/number_6,!text/qwertysyms_y,!text/morekeys_d" />
     <Key
-        latin:keySpec="l"
+        latin:keySpec="d"
         latin:moreKeys="!text/number_7,!text/qwertysyms_u,!text/morekeys_l" />
     <Key
-        latin:keySpec="j"
+        latin:keySpec="l"
         latin:moreKeys="!text/number_8,!text/qwertysyms_i,!text/morekeys_j" />
     <Key
-        latin:keySpec="z"
+        latin:keySpec="j"
         latin:moreKeys="!text/number_9,!text/qwertysyms_o,!text/morekeys_z" />
     <Key
-        latin:keySpec="w"
+        latin:keySpec="z"
         latin:moreKeys="!text/number_0,!text/qwertysyms_p,!text/morekeys_w" />
+    <Key
+        latin:keySpec="w"/>
 </merge>

--- a/java/res/xml/rowkeys_bepo2.xml
+++ b/java/res/xml/rowkeys_bepo2.xml
@@ -46,4 +46,6 @@
     <Key
         latin:keySpec="m"
         latin:moreKeys="!text/morekeys_c" />
+    <Key
+        latin:keySpec="ç"/>
 </merge>

--- a/java/res/xml/rowkeys_bepo3.xml
+++ b/java/res/xml/rowkeys_bepo3.xml
@@ -17,6 +17,10 @@
     xmlns:latin="http://schemas.android.com/apk/res-auto"
 >
     <Key
+        latin:keySpec="ê"/>
+    <Key
+        latin:keySpec="à"/>
+    <Key
         latin:keySpec="y"
         latin:moreKeys="!text/qwertysyms_z,!text/morekeys_y" />
     <Key

--- a/java/res/xml/rows_bepo.xml
+++ b/java/res/xml/rows_bepo.xml
@@ -20,24 +20,22 @@
         latin:keyboardLayout="@xml/key_styles_common" />
     <include latin:keyboardLayout="@xml/row_number_switch" />
     <Row
-        latin:keyWidth="10%p"
+        latin:keyWidth="9%p"
     >
         <include
             latin:keyboardLayout="@xml/rowkeys_bepo1" />
     </Row>
     <Row
-        latin:keyWidth="10%p"
+        latin:keyWidth="9%p"
     >
         <include
             latin:keyboardLayout="@xml/rowkeys_bepo2" />
     </Row>
     <Row
-        latin:keyWidth="10%p"
+        latin:keyWidth="9%p"
     >
         <Key
-            latin:keyStyle="shiftKeyStyle"
-            latin:keyWidth="15%p"
-            latin:visualInsetsRight="1%p" />
+            latin:keyStyle="shiftKeyStyle"/>
         <include
             latin:keyboardLayout="@xml/rowkeys_bepo3" />
         <Key
@@ -46,5 +44,5 @@
             latin:visualInsetsLeft="1%p" />
     </Row>
     <include
-        latin:keyboardLayout="@xml/row_qwerty4" />
+        latin:keyboardLayout="@xml/row_bepo4" />
 </merge>


### PR DESCRIPTION
Adding accent keys missing on the bépo layout (è, ç, ê, à), as well as an apostrophe (') on the fourth row.
Here is the updated layout:
![signal-2024-08-07-131028_002](https://github.com/user-attachments/assets/7e1689b5-e179-408e-9492-433fc8e300a1)
![signal-2024-08-07-131028_003](https://github.com/user-attachments/assets/fc850d5e-3928-4685-8c47-56dbf8b4136b)

This is my first PR on this repo, tell me if something can be improved :)