### PR TITLE
Fixed: Tick for comma #498

### DIFF
--- a/tools/make-keyboard-text-py/locales/hy.json
+++ b/tools/make-keyboard-text-py/locales/hy.json
@@ -33,8 +33,8 @@
         ]
     },
     "keyspec": {
-        "comma": "՝",
-        "tablet_comma": "՝",
+        "comma": ",",
+        "tablet_comma": ",",
         "period": "։",
         "tablet_period": "։"
     },


### PR DESCRIPTION
The Armenian keyboard lacked a comma, and in place of a comma there was a tick.
Fixes #498