### PR TITLE
Add "/"  to the additional keys from ñ character in Spanish layout

### DIFF
--- a/tests/src/org/futo/inputmethod/keyboard/layout/customizer/SpanishCustomizer.java
+++ b/tests/src/org/futo/inputmethod/keyboard/layout/customizer/SpanishCustomizer.java
@@ -89,6 +89,7 @@ public class SpanishCustomizer extends LayoutCustomizer {
                         "\u00E6", "\u0101", "\u00AA")
                 // U+00F1: "ñ" LATIN SMALL LETTER N WITH TILDE
                 .replaceKeyOfLabel(Spanish.ROW2_10, "\u00F1")
+                .setMoreKeysOf("\u00F1", "/")
                 // U+00E7: "ç" LATIN SMALL LETTER C WITH CEDILLA
                 // U+0107: "ć" LATIN SMALL LETTER C WITH ACUTE
                 // U+010D: "č" LATIN SMALL LETTER C WITH CARON

--- a/tools/make-keyboard-text-py/locales/es.json
+++ b/tools/make-keyboard-text-py/locales/es.json
@@ -91,5 +91,8 @@
     "keylabel": {},
     "keyhintlabel": {},
     "additional_morekeys": {},
-    "other": {}
+    "other": {},
+    "qwertysyms": {
+        "ñ": "/"
+    }
 }


### PR DESCRIPTION
Solves #386 .

Code may be completely wrong, I just went for what seemed intuitive to get the ball rolling, but I didn't even build it, let alone test it. If not enough, let me know!