### PR TITLE
Fix: remove non-exsisting symbol form UK

### DIFF
--- a/tests/src/org/futo/inputmethod/keyboard/layout/tests/TestsUkrainian.java
+++ b/tests/src/org/futo/inputmethod/keyboard/layout/tests/TestsUkrainian.java
@@ -17,7 +17,7 @@
 package org.futo.inputmethod.keyboard.layout.tests;
 
 import android.test.suitebuilder.annotation.SmallTest;
-import java.util.Locale;
+
 import org.futo.inputmethod.keyboard.layout.EastSlavic;
 import org.futo.inputmethod.keyboard.layout.LayoutBase;
 import org.futo.inputmethod.keyboard.layout.Symbols;
@@ -26,65 +26,57 @@ import org.futo.inputmethod.keyboard.layout.customizer.EastSlavicCustomizer;
 import org.futo.inputmethod.keyboard.layout.expected.ExpectedKey;
 import org.futo.inputmethod.keyboard.layout.expected.ExpectedKeyboardBuilder;
 
+import java.util.Locale;
+
 /**
  * uk: Ukrainian/east_slavic
  */
 @SmallTest
 public final class TestsUkrainian extends LayoutTestsBase {
-  private static final Locale LOCALE = new Locale("uk");
-  private static final LayoutBase LAYOUT = new EastSlavic(new UkrainianCustomizer(LOCALE));
-
-  @Override
-  LayoutBase getLayout() {
-    return LAYOUT;
-  }
-
-  private static class UkrainianCustomizer extends EastSlavicCustomizer {
-    UkrainianCustomizer(final Locale locale) {
-      super(locale);
-    }
+    private static final Locale LOCALE = new Locale("uk");
+    private static final LayoutBase LAYOUT = new EastSlavic(new UkrainianCustomizer(LOCALE));
 
     @Override
-    public ExpectedKey getCurrencyKey() {
-      return CURRENCY_HRYVNIA;
-    }
+    LayoutBase getLayout() { return LAYOUT; }
 
-    @Override
-    public ExpectedKey[] getOtherCurrencyKeys() {
-      return SymbolsShifted.CURRENCIES_OTHER_GENERIC;
-    }
+    private static class UkrainianCustomizer extends EastSlavicCustomizer {
+        UkrainianCustomizer(final Locale locale) { super(locale); }
 
-    @Override
-    public ExpectedKey[] getDoubleQuoteMoreKeys() {
-      return Symbols.DOUBLE_QUOTES_R9L;
-    }
+        @Override
+        public ExpectedKey getCurrencyKey() { return CURRENCY_HRYVNIA; }
 
-    @Override
-    public ExpectedKey[] getSingleQuoteMoreKeys() {
-      return Symbols.SINGLE_QUOTES_R9L;
-    }
+        @Override
+        public ExpectedKey[] getOtherCurrencyKeys() {
+            return SymbolsShifted.CURRENCIES_OTHER_GENERIC;
+        }
 
-    // U+20B4: "₴" HRYVNIA SIGN
-    private static final ExpectedKey CURRENCY_HRYVNIA =
-        key("\u20B4", Symbols.CURRENCY_GENERIC_MORE_KEYS);
+        @Override
+        public ExpectedKey[] getDoubleQuoteMoreKeys() { return Symbols.DOUBLE_QUOTES_R9L; }
 
-    @Override
-    public ExpectedKeyboardBuilder setAccentedLetters(final ExpectedKeyboardBuilder builder) {
-      return builder
-          // U+0433: "г" CYRILLIC SMALL LETTER GHE
-          // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
-          .setMoreKeysOf("\u0433", "\u0491")
-          // U+0449: "щ" CYRILLIC SMALL LETTER SHCHA
-          .replaceKeyOfLabel(EastSlavic.ROW1_9, key("\u0449", additionalMoreKey("9")))
-          // U+0456: "і" CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-          // U+0457: "ї" CYRILLIC SMALL LETTER YI
-          .replaceKeyOfLabel(EastSlavic.ROW2_2, key("\u0456", moreKey("\u0457")))
-          // U+0454: "є" CYRILLIC SMALL LETTER UKRAINIAN IE
-          .replaceKeyOfLabel(EastSlavic.ROW2_11, "\u0454")
-          // U+0438: "и" CYRILLIC SMALL LETTER I
-          .replaceKeyOfLabel(EastSlavic.ROW3_5, "\u0438")
-          // U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN
-          .setMoreKeysOf("\u044C");
+        @Override
+        public ExpectedKey[] getSingleQuoteMoreKeys() { return Symbols.SINGLE_QUOTES_R9L; }
+
+        // U+20B4: "₴" HRYVNIA SIGN
+        private static final ExpectedKey CURRENCY_HRYVNIA = key("\u20B4",
+                Symbols.CURRENCY_GENERIC_MORE_KEYS);
+
+        @Override
+        public ExpectedKeyboardBuilder setAccentedLetters(final ExpectedKeyboardBuilder builder) {
+            return builder
+                    // U+0433: "г" CYRILLIC SMALL LETTER GHE
+                    // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
+                    .setMoreKeysOf("\u0433", "\u0491")
+                    // U+0449: "щ" CYRILLIC SMALL LETTER SHCHA
+                    .replaceKeyOfLabel(EastSlavic.ROW1_9, key("\u0449", additionalMoreKey("9")))
+                    // U+0456: "і" CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+                    // U+0457: "ї" CYRILLIC SMALL LETTER YI
+                    .replaceKeyOfLabel(EastSlavic.ROW2_2, key("\u0456", moreKey("\u0457")))
+                    // U+0454: "є" CYRILLIC SMALL LETTER UKRAINIAN IE
+                    .replaceKeyOfLabel(EastSlavic.ROW2_11, "\u0454")
+                    // U+0438: "и" CYRILLIC SMALL LETTER I
+                    .replaceKeyOfLabel(EastSlavic.ROW3_5, "\u0438")
+                    // U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN
+                    .setMoreKeysOf("\u044C");
+        }
     }
-  }
 }

--- a/tests/src/org/futo/inputmethod/keyboard/layout/tests/TestsUkrainian.java
+++ b/tests/src/org/futo/inputmethod/keyboard/layout/tests/TestsUkrainian.java
@@ -17,7 +17,7 @@
 package org.futo.inputmethod.keyboard.layout.tests;
 
 import android.test.suitebuilder.annotation.SmallTest;
-
+import java.util.Locale;
 import org.futo.inputmethod.keyboard.layout.EastSlavic;
 import org.futo.inputmethod.keyboard.layout.LayoutBase;
 import org.futo.inputmethod.keyboard.layout.Symbols;
@@ -26,58 +26,65 @@ import org.futo.inputmethod.keyboard.layout.customizer.EastSlavicCustomizer;
 import org.futo.inputmethod.keyboard.layout.expected.ExpectedKey;
 import org.futo.inputmethod.keyboard.layout.expected.ExpectedKeyboardBuilder;
 
-import java.util.Locale;
-
 /**
  * uk: Ukrainian/east_slavic
  */
 @SmallTest
 public final class TestsUkrainian extends LayoutTestsBase {
-    private static final Locale LOCALE = new Locale("uk");
-    private static final LayoutBase LAYOUT = new EastSlavic(new UkrainianCustomizer(LOCALE));
+  private static final Locale LOCALE = new Locale("uk");
+  private static final LayoutBase LAYOUT = new EastSlavic(new UkrainianCustomizer(LOCALE));
+
+  @Override
+  LayoutBase getLayout() {
+    return LAYOUT;
+  }
+
+  private static class UkrainianCustomizer extends EastSlavicCustomizer {
+    UkrainianCustomizer(final Locale locale) {
+      super(locale);
+    }
 
     @Override
-    LayoutBase getLayout() { return LAYOUT; }
-
-    private static class UkrainianCustomizer extends EastSlavicCustomizer {
-        UkrainianCustomizer(final Locale locale) { super(locale); }
-
-        @Override
-        public ExpectedKey getCurrencyKey() { return CURRENCY_HRYVNIA; }
-
-        @Override
-        public ExpectedKey[] getOtherCurrencyKeys() {
-            return SymbolsShifted.CURRENCIES_OTHER_GENERIC;
-        }
-
-        @Override
-        public ExpectedKey[] getDoubleQuoteMoreKeys() { return Symbols.DOUBLE_QUOTES_R9L; }
-
-        @Override
-        public ExpectedKey[] getSingleQuoteMoreKeys() { return Symbols.SINGLE_QUOTES_R9L; }
-
-        // U+20B4: "₴" HRYVNIA SIGN
-        private static final ExpectedKey CURRENCY_HRYVNIA = key("\u20B4",
-                Symbols.CURRENCY_GENERIC_MORE_KEYS);
-
-        @Override
-        public ExpectedKeyboardBuilder setAccentedLetters(final ExpectedKeyboardBuilder builder) {
-            return builder
-                    // U+0433: "г" CYRILLIC SMALL LETTER GHE
-                    // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
-                    .setMoreKeysOf("\u0433", "\u0491")
-                    // U+0449: "щ" CYRILLIC SMALL LETTER SHCHA
-                    .replaceKeyOfLabel(EastSlavic.ROW1_9, key("\u0449", additionalMoreKey("9")))
-                    // U+0456: "і" CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-                    // U+0457: "ї" CYRILLIC SMALL LETTER YI
-                    .replaceKeyOfLabel(EastSlavic.ROW2_2, key("\u0456", moreKey("\u0457")))
-                    // U+0454: "є" CYRILLIC SMALL LETTER UKRAINIAN IE
-                    .replaceKeyOfLabel(EastSlavic.ROW2_11, "\u0454")
-                    // U+0438: "и" CYRILLIC SMALL LETTER I
-                    .replaceKeyOfLabel(EastSlavic.ROW3_5, "\u0438")
-                    // U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN
-                    // U+044A: "ъ" CYRILLIC SMALL LETTER HARD SIGN
-                    .setMoreKeysOf("\u044C", "\u044A");
-        }
+    public ExpectedKey getCurrencyKey() {
+      return CURRENCY_HRYVNIA;
     }
+
+    @Override
+    public ExpectedKey[] getOtherCurrencyKeys() {
+      return SymbolsShifted.CURRENCIES_OTHER_GENERIC;
+    }
+
+    @Override
+    public ExpectedKey[] getDoubleQuoteMoreKeys() {
+      return Symbols.DOUBLE_QUOTES_R9L;
+    }
+
+    @Override
+    public ExpectedKey[] getSingleQuoteMoreKeys() {
+      return Symbols.SINGLE_QUOTES_R9L;
+    }
+
+    // U+20B4: "₴" HRYVNIA SIGN
+    private static final ExpectedKey CURRENCY_HRYVNIA =
+        key("\u20B4", Symbols.CURRENCY_GENERIC_MORE_KEYS);
+
+    @Override
+    public ExpectedKeyboardBuilder setAccentedLetters(final ExpectedKeyboardBuilder builder) {
+      return builder
+          // U+0433: "г" CYRILLIC SMALL LETTER GHE
+          // U+0491: "ґ" CYRILLIC SMALL LETTER GHE WITH UPTURN
+          .setMoreKeysOf("\u0433", "\u0491")
+          // U+0449: "щ" CYRILLIC SMALL LETTER SHCHA
+          .replaceKeyOfLabel(EastSlavic.ROW1_9, key("\u0449", additionalMoreKey("9")))
+          // U+0456: "і" CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+          // U+0457: "ї" CYRILLIC SMALL LETTER YI
+          .replaceKeyOfLabel(EastSlavic.ROW2_2, key("\u0456", moreKey("\u0457")))
+          // U+0454: "є" CYRILLIC SMALL LETTER UKRAINIAN IE
+          .replaceKeyOfLabel(EastSlavic.ROW2_11, "\u0454")
+          // U+0438: "и" CYRILLIC SMALL LETTER I
+          .replaceKeyOfLabel(EastSlavic.ROW3_5, "\u0438")
+          // U+044C: "ь" CYRILLIC SMALL LETTER SOFT SIGN
+          .setMoreKeysOf("\u044C");
+    }
+  }
 }

--- a/tools/make-keyboard-text-py/locales/uk.json
+++ b/tools/make-keyboard-text-py/locales/uk.json
@@ -6,9 +6,6 @@
         ],
         "east_slavic_row2_2": [
             "ї"
-        ],
-        "cyrillic_soft_sign": [
-            "ъ"
         ]
     },
     "keyspec": {


### PR DESCRIPTION
Removes non-existing symbol from Ukrainian language.

See https://en.wikipedia.org/wiki/Ukrainian_alphabet for reference.