### PR TITLE
Reduce minimum column size on clipboard history view

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
@@ -589,7 +589,7 @@ val ClipboardHistoryAction = Action(
                 } else {
                     LazyVerticalStaggeredGrid(
                         modifier = Modifier.fillMaxWidth(),
-                        columns = StaggeredGridCells.Adaptive(180.dp),
+                        columns = StaggeredGridCells.Adaptive(120.dp),
                         verticalItemSpacing = 4.dp,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {


### PR DESCRIPTION
#1207 Says a user wants grid view to the clipboard history view. But seems like grid view is already being used. Just reduced the min size for an entry so more items are packed into the panel.

EDIT: mentioning clipboard history