### PR TITLE
Fix crash and incorrect inline suggestion alignment

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/InlineSuggestionView.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/InlineSuggestionView.kt
@@ -17,19 +17,15 @@ import androidx.autofill.inline.common.ImageViewStyle
 import androidx.autofill.inline.common.TextViewStyle
 import androidx.autofill.inline.common.ViewStyle
 import androidx.autofill.inline.v1.InlineSuggestionUi
-import androidx.compose.foundation.clipScrollableContainer
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.toArgb
@@ -173,13 +169,13 @@ fun InlineSuggestionView(inlineSuggestion: MutableState<View?>) {
 @RequiresApi(Build.VERSION_CODES.R)
 @Composable
 fun RowScope.InlineSuggestions(suggestions: List<MutableState<View?>>) {
-    val scrollState = rememberScrollState()
-    LazyRow(modifier = Modifier
+    LazyRow(
+        modifier = Modifier
             .weight(1.0f)
-            .padding(0.dp, 4.dp)
-            .horizontalScroll(scrollState)
-            .clipScrollableContainer(Orientation.Horizontal)
-            .clipToBounds()) {
+            .fillMaxHeight()
+            .clipToBounds(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         suggestions.forEach { item { InlineSuggestionView(it) } }
     }
 }


### PR DESCRIPTION
Having the `.horizontalScroll()` modifier on a LazyRow causes android to think it has an infinite maximum width, leading to a crash. 
Other than that the inline suggestions were getting cut off at the bottom due to the padding. As I couldn't correct the padding in a way that fixed the visual issues and the size of the elements didn't seem to depend on that padding I chose to vertically center them in the LazyRow instead.