### PR TITLE
Feature: Add multiplier to swipe-based cursor movement based on y

### DIFF
--- a/common/src/org/futo/inputmethod/latin/common/CoordinateUtils.java
+++ b/common/src/org/futo/inputmethod/latin/common/CoordinateUtils.java
@@ -91,4 +91,8 @@ public final class CoordinateUtils {
             @Nonnull final int[] coords) {
         setXYInArray(coordsArray, index, x(coords), y(coords));
     }
+
+    public static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
 }

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -935,6 +935,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             }
 
             int steps = (x - mStartX) / pointerStep;
+            int STEP_MULTIPLIER_STAGES = 3;
+            int spaceY = oldKey.getY();
+            int step_multiplier = STEP_MULTIPLIER_STAGES - CoordinateUtils.clamp(y, 0, spaceY - 1) * STEP_MULTIPLIER_STAGES / spaceY - 1;
+
             final int swipeIgnoreTime = settingsValues.mKeyLongpressTimeout / MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
             if (steps != 0 && mStartTime + swipeIgnoreTime < System.currentTimeMillis()) {
                 mCursorMoved = true;
@@ -943,7 +947,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 if(settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE && !mSpacebarLongPressed) {
                     sListener.onSwipeLanguage(steps);
                 } else {
-                    sListener.onMovePointer(steps);
+                    sListener.onMovePointer(steps << step_multiplier);
                 }
             }
 


### PR DESCRIPTION
Moving 1 character at a time makes the feature impractical outside of minor adjustments after tapping on text. This change splits the keyboard into 3 bands between the spacebar and the top of the keyboard, and when swiping, moves the cursor by 2^band characters.

Note that this would contrary to the open ticket #1417 as the y axis would be overloaded, perhaps a new setting to switch between behaviours would be desirable?