### PR TITLE
Make Armenian layout show the ASCII comma ',' on the comma key

### DIFF
--- a/tools/make-keyboard-text-py/locales/hy.json
+++ b/tools/make-keyboard-text-py/locales/hy.json
@@ -33,8 +33,6 @@
         ]
     },
     "keyspec": {
-        "comma": "՝",
-        "tablet_comma": "՝",
         "period": "։",
         "tablet_period": "։",
         "currency": "֏"


### PR DESCRIPTION
Fix https://github.com/futo-org/futo-keyboard-layouts/issues/28