### PR TITLE
feat: Add Quick Settings tile to temporarily hide keyboard

### DIFF
--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -63,6 +63,18 @@
         </service>
         -->
 
+        <!-- Quick Settings Tile for hiding keyboard (API 24+) -->
+        <service
+            android:name=".qs.HideKeyboardTileService"
+            android:icon="@drawable/ic_keyboard_hide"
+            android:label="@string/qs_tile_hide_keyboard_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <!-- Activities -->
         <activity android:name=".uix.settings.SettingsActivity"
              android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"

--- a/java/res/drawable/ic_keyboard_hide.xml
+++ b/java/res/drawable/ic_keyboard_hide.xml
@@ -1,0 +1,35 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Keyboard base -->
+    <path
+        android:pathData="M4,5h16a2,2 0,0 1,2 2v10a2,2 0,0 1,-2 2H4a2,2 0,0 1,-2 -2V7a2,2 0,0 1,2 -2z"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <!-- Keys row 1 -->
+    <path
+        android:pathData="M6,9h1M10,9h1M14,9h1M18,9h1"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"/>
+    <!-- Keys row 2 -->
+    <path
+        android:pathData="M6,13h1M10,13h1M14,13h1M18,13h1"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"/>
+    <!-- Diagonal strike-through line -->
+    <path
+        android:pathData="M3,3L21,21"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeLineCap="round"/>
+</vector>

--- a/java/res/values/strings.xml
+++ b/java/res/values/strings.xml
@@ -274,4 +274,11 @@ mobile devices. [CHAR LIMIT=25] -->
          This resource is copied from packages/apps/Settings/res/values/strings.xml -->
     <!-- This resource is corresponding to msgid="5433275485499039199" -->
     <string name="user_dict_fast_scroll_alphabet">\u0020ABCDEFGHIJKLMNOPQRSTUVWXYZ</string>
+
+    <!-- Quick Settings tile for hiding keyboard -->
+    <string name="qs_tile_hide_keyboard_label">Keyboard</string>
+    <string name="qs_tile_keyboard_normal">Keyboard</string>
+    <string name="qs_tile_keyboard_suppressed">Keyboard Off</string>
+    <string name="qs_tile_keyboard_suppressed_toast">Keyboard will not appear automatically</string>
+    <string name="qs_tile_keyboard_enabled_toast">Keyboard will appear normally</string>
 </resources>

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -67,6 +67,7 @@ import org.futo.inputmethod.latin.uix.HiddenKeysSetting
 import org.futo.inputmethod.latin.uix.KeyBordersSetting
 import org.futo.inputmethod.latin.uix.KeyHintsSetting
 import org.futo.inputmethod.latin.uix.KeyboardColorScheme
+import org.futo.inputmethod.latin.uix.KEYBOARD_SUPPRESSED
 import org.futo.inputmethod.latin.uix.SUGGESTION_BLACKLIST
 import org.futo.inputmethod.latin.uix.THEME_KEY
 import org.futo.inputmethod.latin.uix.UixManager
@@ -717,6 +718,9 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
     }
 
     override fun onShowInputRequested(flags: Int, configChange: Boolean): Boolean {
+        if (isKeyboardSuppressed()) {
+            return false
+        }
         return latinIMELegacy.onShowInputRequested(
             flags,
             configChange
@@ -724,7 +728,14 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
     }
 
     override fun onEvaluateInputViewShown(): Boolean {
+        if (isKeyboardSuppressed()) {
+            return false
+        }
         return latinIMELegacy.onEvaluateInputViewShown() || super.onEvaluateInputViewShown()
+    }
+
+    private fun isKeyboardSuppressed(): Boolean {
+        return getSettingBlocking(KEYBOARD_SUPPRESSED)
     }
 
     override fun onEvaluateFullscreenMode(): Boolean {

--- a/java/src/org/futo/inputmethod/latin/qs/HideKeyboardTileService.kt
+++ b/java/src/org/futo/inputmethod/latin/qs/HideKeyboardTileService.kt
@@ -1,0 +1,57 @@
+package org.futo.inputmethod.latin.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.KEYBOARD_SUPPRESSED
+import org.futo.inputmethod.latin.uix.getSettingBlocking
+import org.futo.inputmethod.latin.uix.setSetting
+
+@RequiresApi(Build.VERSION_CODES.N)
+class HideKeyboardTileService : TileService() {
+
+    override fun onStartListening() {
+        super.onStartListening()
+        syncTileStateFromPrefs()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val newSuppressed = !applicationContext.getSettingBlocking(KEYBOARD_SUPPRESSED)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            applicationContext.setSetting(KEYBOARD_SUPPRESSED, newSuppressed)
+        }
+
+        updateTile(newSuppressed)
+
+        val message = if (newSuppressed) {
+            getString(R.string.qs_tile_keyboard_suppressed_toast)
+        } else {
+            getString(R.string.qs_tile_keyboard_enabled_toast)
+        }
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun syncTileStateFromPrefs() {
+        updateTile(applicationContext.getSettingBlocking(KEYBOARD_SUPPRESSED))
+    }
+
+    private fun updateTile(suppressed: Boolean) {
+        val tile = qsTile ?: return
+        tile.state = if (suppressed) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = if (suppressed) {
+            getString(R.string.qs_tile_keyboard_suppressed)
+        } else {
+            getString(R.string.qs_tile_keyboard_normal)
+        }
+        tile.contentDescription = tile.label
+        tile.updateTile()
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/Settings.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Settings.kt
@@ -388,3 +388,8 @@ val SHOW_EMOJI_SUGGESTIONS = SettingsKey(
     key = booleanPreferencesKey("suggestEmojis"),
     default = true
 )
+
+val KEYBOARD_SUPPRESSED = SettingsKey(
+    key = booleanPreferencesKey("keyboardSuppressed"),
+    default = false
+)


### PR DESCRIPTION
Closes #1787

## Summary
Adds a Quick Settings tile (API 24+) that allows users to temporarily suppress the keyboard from appearing. When enabled, the keyboard will not pop up when text fields are focused, which is useful for reading/annotating text without keyboard interference.

## Changes

| File | Description |
|------|-------------|
| `java/src/org/futo/inputmethod/latin/qs/HideKeyboardTileService.kt` | New TileService that toggles keyboard suppression |
| `java/res/drawable/ic_keyboard_hide.xml` | Vector icon for the Quick Settings tile |
| `java/src/org/futo/inputmethod/latin/uix/Settings.kt` | Added `KEYBOARD_SUPPRESSED` preference key |
| `java/src/org/futo/inputmethod/latin/LatinIME.kt` | Modified `onShowInputRequested()` and `onEvaluateInputViewShown()` to honor suppress flag |
| `java/res/values/strings.xml` | Added tile labels and toast messages |
| `java/AndroidManifest.xml` | Registered the TileService |

## How it works
1. User adds the "Keyboard" tile from Quick Settings panel
2. Tapping the tile toggles suppression and shows a confirmation toast
3. When suppressed, the IME returns `false` from `onShowInputRequested()` and `onEvaluateInputViewShown()`, preventing automatic keyboard popup
4. Tap again to restore normal behavior

## Testing
- [ ] Add tile from Quick Settings panel
- [ ] Toggle ON → keyboard should not appear when tapping text fields
- [ ] Toggle OFF → keyboard appears normally
- [ ] Tile state persists across app restarts
- [ ] Toast messages display correctly