### PR TITLE
Enable predictive back gesture

### DIFF
--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -35,6 +35,7 @@
          android:supportsRtl="true"
          android:allowBackup="true"
          android:largeHeap="true"
+         android:enableOnBackInvokedCallback="true"
          android:name=".CrashLoggingApplication">
 
         <!-- Services -->


### PR DESCRIPTION
Fixes #497 

This PR enables support for Android's [predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) for the main settings activity and for the keyboard itself. For reference, Gboard integrated this sometime in 2024.

I tested this on-device using a Google Pixel 9 running GrapheneOS based on Android 16.


Before:

https://github.com/user-attachments/assets/d8b27a31-3b02-4505-a416-f95be65f750e


After:


https://github.com/user-attachments/assets/6d28f997-2c23-4e1a-8c90-b592e12f9f89


Thanks!!
