### PR TITLE
Add haptic feedback for spacebar and backspace swipe gestures

### DIFF
--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -1001,6 +1001,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 if(settingsValues.mIsRTL) steps = -steps;
 
                 sListener.onMoveDeletePointer(steps);
+                final AudioAndHapticFeedbackManager feedbackManager =
+                        AudioAndHapticFeedbackManager.getInstance();
+                if (settingsValues.mVibrateOn) {
+                    feedbackManager.vibrate(CURSOR_MOVE_VIBRATION_DURATION);
+                }
             }
 
             mLastX = x;

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -34,6 +34,7 @@ import org.futo.inputmethod.keyboard.internal.KeyboardState;
 import org.futo.inputmethod.keyboard.internal.PointerTrackerQueue;
 import org.futo.inputmethod.keyboard.internal.TimerProxy;
 import org.futo.inputmethod.keyboard.internal.TypingTimeRecorder;
+import org.futo.inputmethod.latin.AudioAndHapticFeedbackManager;
 import org.futo.inputmethod.latin.R;
 import org.futo.inputmethod.latin.common.Constants;
 import org.futo.inputmethod.latin.common.CoordinateUtils;
@@ -161,6 +162,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private MoreKeysPanel mMoreKeysPanel;
 
     private static final int MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT = 3;
+    // Short vibration duration (ms) for each cursor step during spacebar swipe.
+    private static final int CURSOR_MOVE_VIBRATION_DURATION = 5;
     // true if this pointer is in the dragging finger mode.
     boolean mIsInDraggingFinger;
     // true if this pointer is sliding from a modifier key and in the sliding key input mode,
@@ -970,6 +973,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                     sListener.onSwipeLanguage(steps);
                 } else {
                     sListener.onMovePointer(steps);
+                    final AudioAndHapticFeedbackManager feedbackManager =
+                            AudioAndHapticFeedbackManager.getInstance();
+                    if (settingsValues.mVibrateOn) {
+                        feedbackManager.vibrate(CURSOR_MOVE_VIBRATION_DURATION);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds per-step haptic feedback when swiping the spacebar to move the cursor and when swiping backspace to delete. Uses the existing `AudioAndHapticFeedbackManager` with a short 5ms vibration pulse per cursor step, gated by the user's vibration preference (`settingsValues.mVibrateOn`).

Closes #747. Also addresses the related request in #693 and #862 (duplicates merged into #747) and the comment requesting the same treatment for gesture delete.

## Changes

- `PointerTracker.java`: Added `CURSOR_MOVE_VIBRATION_DURATION` constant (5ms) and haptic feedback calls after `onMovePointer()` (spacebar swipe) and `onMoveDeletePointer()` (backspace swipe).

## Test plan

- [ ] Verify haptic pulse is felt on each cursor step when swiping spacebar
- [ ] Verify haptic pulse is felt on each delete step when swiping backspace
- [ ] Verify no vibration occurs when haptic feedback is disabled in settings
- [ ] Verify no behavioral change to cursor movement or deletion logic

Co-authored with Claude Code.