### PR TITLE
Add coding bar with sticky modifier keys for terminal/coding use

### DIFF
--- a/java/res/drawable/ic_coding_alt.xml
+++ b/java/res/drawable/ic_coding_alt.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Alt key symbol: two diagonal lines forming a tent/peak -->
+  <path
+      android:pathData="M4,17l5,-10h2l5,10"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6.5,13h7"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_bar.xml
+++ b/java/res/drawable/ic_coding_bar.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Terminal / code prompt icon: >_ -->
+  <path
+      android:pathData="M4,17l6,-5l-6,-5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,19h8"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_ctrl.xml
+++ b/java/res/drawable/ic_coding_ctrl.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Caret / chevron up symbol (^) representing Ctrl -->
+  <path
+      android:pathData="M6,15l6,-6l6,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_dash.xml
+++ b/java/res/drawable/ic_coding_dash.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Dash / minus -->
+  <path
+      android:pathData="M6,12h12"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_esc.xml
+++ b/java/res/drawable/ic_coding_esc.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- X mark representing Escape -->
+  <path
+      android:pathData="M7,7l10,10"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17,7l-10,10"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_shift.xml
+++ b/java/res/drawable/ic_coding_shift.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Upward arrow / shift symbol -->
+    <path
+        android:pathData="M12,4L4,14h5v6h6v-6h5z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FFFFFF"
+        android:fillColor="@android:color/transparent" />
+</vector>

--- a/java/res/drawable/ic_coding_slash.xml
+++ b/java/res/drawable/ic_coding_slash.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Forward slash -->
+  <path
+      android:pathData="M15,5l-6,14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/drawable/ic_coding_tab.xml
+++ b/java/res/drawable/ic_coding_tab.xml
@@ -1,0 +1,28 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Right arrow with bar (Tab symbol) -->
+  <path
+      android:pathData="M6,9l3,3l-3,3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6,12h10"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18,8v8"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -18,6 +18,16 @@
     <string name="action_cursor_left_title">Arrow Left</string>
     <string name="action_cursor_right_title">Arrow Right</string>
 
+    <!-- Coding bar actions -->
+    <string name="action_coding_tab_title">Tab</string>
+    <string name="action_coding_ctrl_title">Ctrl</string>
+    <string name="action_coding_alt_title">Alt</string>
+    <string name="action_coding_slash_title">Slash</string>
+    <string name="action_coding_dash_title">Dash</string>
+    <string name="action_coding_esc_title">Escape</string>
+    <string name="action_coding_shift_title">Shift</string>
+    <string name="action_coding_bar_title">Coding Bar</string>
+
     <!-- For emoji menu action -->
     <string name="action_emoji_title">Emojis</string>
     <!-- Refers to the most recently used emojis -->
@@ -470,6 +480,8 @@
     <string name="keyboard_settings_extra_layouts_subtitle">Configure additional layouts in the languages screen</string>
     <string name="keyboard_settings_show_suggestion_row">Show action/suggestions bar</string>
     <string name="keyboard_settings_show_suggestion_row_subtitle">Show the bar containing suggestions. Recommended to keep enabled</string>
+    <string name="keyboard_settings_show_coding_bar">Show coding bar</string>
+    <string name="keyboard_settings_show_coding_bar_subtitle">Replace the suggestion bar with shortcut keys for coding (TAB, CTRL, ALT, ESC, etc.)</string>
     <string name="keyboard_settings_inline_autofill">Inline autofill</string>
     <string name="keyboard_settings_inline_autofill_subtitle">Display password manager autofill and auto-reply suggestions (provided by app) in suggestion bar</string>
     <string name="keyboard_settings_period_key">Quick period key</string>

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -58,6 +58,7 @@ import org.futo.inputmethod.engine.general.WordLearner
 import org.futo.inputmethod.latin.SuggestedWords.SuggestedWordInfo
 import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.settings.Settings
+import org.futo.inputmethod.latin.uix.actions.CodingModifierState
 import org.futo.inputmethod.latin.uix.BasicThemeProvider
 import org.futo.inputmethod.latin.uix.DataStoreHelper
 import org.futo.inputmethod.latin.uix.DynamicThemeProvider
@@ -621,6 +622,9 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         super.onWindowHidden()
         latinIMELegacy.onWindowHidden()
         uixManager.onInputFinishing()
+        // Full reset of coding bar modifier state (including locked modifiers)
+        // so no buttons remain highlighted on reopen
+        CodingModifierState.resetAll()
     }
 
     override fun onUpdateSelection(

--- a/java/src/org/futo/inputmethod/latin/uix/CodingBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/CodingBar.kt
@@ -1,0 +1,243 @@
+package org.futo.inputmethod.latin.uix
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.futo.inputmethod.latin.common.Constants
+import org.futo.inputmethod.latin.uix.actions.CodingAltAction
+import org.futo.inputmethod.latin.uix.actions.CodingCtrlAction
+import org.futo.inputmethod.latin.uix.actions.CodingDashAction
+import org.futo.inputmethod.latin.uix.actions.CodingEscAction
+import org.futo.inputmethod.latin.uix.actions.CodingModifierState
+import org.futo.inputmethod.latin.uix.actions.CodingShiftAction
+import org.futo.inputmethod.latin.uix.actions.CodingSlashAction
+import org.futo.inputmethod.latin.uix.actions.CodingTabAction
+
+/**
+ * A coding-focused bar that replaces the action/suggestions bar when enabled.
+ * Displays shortcut buttons for TAB, CTRL, ALT, SHIFT, /, -, ESC.
+ *
+ * Modifier keys (CTRL, ALT, SHIFT) support two modes:
+ * - **Single press**: One-shot — consumed after the next key press.
+ * - **Long press**: Locked — stays active across multiple key presses.
+ *   A border around the button indicates the locked state.
+ *   Press the button again (short press) to unlock.
+ *
+ * All states (active + locked) are fully reactive via Compose [mutableStateOf]
+ * in [CodingModifierState], and are fully reset when the keyboard hides.
+ */
+
+private val codingKeyTextStyle = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight.Bold,
+    fontSize = 11.sp,
+    letterSpacing = 0.3.sp,
+    textAlign = TextAlign.Center
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CodingKeyButton(
+    label: String,
+    action: Action,
+    onActionActivated: (Action) -> Unit,
+    isHighlighted: Boolean = false,
+    isLocked: Boolean = false,
+    onLongClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    val haptic = LocalHapticFeedback.current
+
+    val fgCol = if (isHighlighted) {
+        LocalKeyboardScheme.current.onPrimary
+    } else {
+        LocalKeyboardScheme.current.onBackground
+    }
+
+    val bgCol = if (isHighlighted) {
+        LocalKeyboardScheme.current.primary
+    } else {
+        LocalKeyboardScheme.current.keyboardContainer
+    }
+
+    val shape = RoundedCornerShape(6.dp)
+
+    // Locked modifiers get a visible border to distinguish from one-shot
+    val borderMod = if (isLocked) {
+        Modifier.border(
+            width = 1.5.dp,
+            color = LocalKeyboardScheme.current.onPrimary.copy(alpha = 0.8f),
+            shape = shape
+        )
+    } else {
+        Modifier
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(horizontal = 1.5.dp, vertical = 4.dp)
+            .clip(shape)
+            .then(borderMod)
+            .background(bgCol)
+            .combinedClickable(
+                onClick = { onActionActivated(action) },
+                onLongClick = if (onLongClick != null) {
+                    {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        onLongClick()
+                    }
+                } else null
+            )
+            .padding(horizontal = 4.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            style = codingKeyTextStyle,
+            color = fgCol,
+            maxLines = 1,
+        )
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun CodingBar(
+    onActionActivated: (Action) -> Unit,
+    onActionAltActivated: (Action) -> Unit,
+    isActionsExpanded: Boolean,
+    toggleActionsExpanded: () -> Unit,
+    keyboardManagerForAction: KeyboardManagerForAction? = null,
+) {
+    val view = LocalView.current
+
+    // Read modifier states directly from CodingModifierState (Compose reactive).
+    val ctrlActive = CodingModifierState.ctrlActive
+    val altActive = CodingModifierState.altActive
+    val shiftActive = CodingModifierState.shiftActive
+    val ctrlLocked = CodingModifierState.ctrlLocked
+    val altLocked = CodingModifierState.altLocked
+    val shiftLocked = CodingModifierState.shiftLocked
+
+    val useDoubleHeight = isActionsExpanded
+
+    Column(
+        Modifier
+            .height(ActionBarHeight * (if (useDoubleHeight) 2 else 1))
+            .semantics {
+                testTag = "CodingBar"
+                testTagsAsResourceId = true
+            }
+    ) {
+        // Expanded favorites row (same as ActionBar)
+        if (isActionsExpanded) {
+            ActionSep()
+
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1.0f),
+                color = LocalKeyboardScheme.current.keyboardSurfaceDim
+            ) {
+                ActionItems(onActionActivated, onActionAltActivated)
+            }
+        }
+
+        ActionSep()
+
+        // Coding bar row
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1.0f),
+            color = actionBarColor()
+        ) {
+            Row(Modifier.safeKeyboardPadding()) {
+                ExpandActionsButton(isActionsExpanded) {
+                    toggleActionsExpanded()
+                    keyboardManagerForAction?.performHapticAndAudioFeedback(
+                        Constants.CODE_TAB,
+                        view
+                    )
+                }
+
+                // TAB — not a modifier, no long press
+                CodingKeyButton("TAB", CodingTabAction, onActionActivated,
+                    modifier = Modifier.weight(1f))
+
+                // CTRL — modifier with lock support
+                CodingKeyButton("CTRL", CodingCtrlAction, onActionActivated,
+                    isHighlighted = ctrlActive,
+                    isLocked = ctrlLocked,
+                    onLongClick = {
+                        CodingModifierState.ctrlActive = true
+                        CodingModifierState.ctrlLocked = true
+                    },
+                    modifier = Modifier.weight(1f))
+
+                // ALT — modifier with lock support
+                CodingKeyButton("ALT", CodingAltAction, onActionActivated,
+                    isHighlighted = altActive,
+                    isLocked = altLocked,
+                    onLongClick = {
+                        CodingModifierState.altActive = true
+                        CodingModifierState.altLocked = true
+                    },
+                    modifier = Modifier.weight(1f))
+
+                // SHIFT — modifier with lock support
+                CodingKeyButton("SHIFT", CodingShiftAction, onActionActivated,
+                    isHighlighted = shiftActive,
+                    isLocked = shiftLocked,
+                    onLongClick = {
+                        CodingModifierState.shiftActive = true
+                        CodingModifierState.shiftLocked = true
+                    },
+                    modifier = Modifier.weight(1.1f))
+
+                // / — not a modifier
+                CodingKeyButton("/", CodingSlashAction, onActionActivated,
+                    modifier = Modifier.weight(0.6f))
+
+                // - — not a modifier
+                CodingKeyButton("-", CodingDashAction, onActionActivated,
+                    modifier = Modifier.weight(0.6f))
+
+                // ESC — not a modifier
+                CodingKeyButton("ESC", CodingEscAction, onActionActivated,
+                    modifier = Modifier.weight(1f))
+            }
+        }
+
+        ActionSep(true)
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/actions/CodingActions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/CodingActions.kt
@@ -1,0 +1,219 @@
+package org.futo.inputmethod.latin.uix.actions
+
+import android.view.KeyEvent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.Action
+import org.futo.inputmethod.latin.uix.getSettingBlocking
+import org.futo.inputmethod.latin.uix.setSettingBlocking
+import org.futo.inputmethod.latin.uix.settings.pages.CodingBarDisplayedSetting
+
+/**
+ * Coding bar actions for sending special key events commonly used during coding:
+ * TAB, CTRL (sticky modifier), ALT (sticky modifier), SHIFT (sticky modifier), /, -, ESC.
+ *
+ * Modifier keys have two modes:
+ * - **Single press (one-shot)**: Activates the modifier for the next key press only,
+ *   then automatically deactivates.
+ * - **Long press (locked)**: Locks the modifier so it stays active across multiple
+ *   key presses. Press the button again (short press) to unlock.
+ *
+ * The coding bar UI highlights active modifiers and shows a border when locked.
+ */
+
+/**
+ * Global sticky modifier state shared between modifier actions and the coding bar UI.
+ *
+ * Uses Compose [mutableStateOf] so that any write (from action handlers, from the
+ * LatinIMELegacy onCodeInput intercept, or from onWindowHidden reset) automatically
+ * triggers recomposition of the CodingBar composable.
+ *
+ * From Java code, access via `CodingModifierState.INSTANCE.getCtrlActive()` /
+ * `CodingModifierState.INSTANCE.setCtrlActive(true)` etc.
+ */
+object CodingModifierState {
+    // Active state (one-shot or locked)
+    var ctrlActive by mutableStateOf(false)
+    var altActive by mutableStateOf(false)
+    var shiftActive by mutableStateOf(false)
+
+    // Locked state (long-press sticky — persists across key presses)
+    var ctrlLocked by mutableStateOf(false)
+    var altLocked by mutableStateOf(false)
+    var shiftLocked by mutableStateOf(false)
+
+    fun getMetaState(): Int {
+        var meta = 0
+        if (ctrlActive) meta = meta or KeyEvent.META_CTRL_ON or KeyEvent.META_CTRL_LEFT_ON
+        if (altActive) meta = meta or KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+        if (shiftActive) meta = meta or KeyEvent.META_SHIFT_ON or KeyEvent.META_SHIFT_LEFT_ON
+        return meta
+    }
+
+    /**
+     * Consume one-shot modifiers after a key press.
+     * Locked modifiers are NOT consumed — they stay active until explicitly unlocked.
+     */
+    fun consumeModifiers() {
+        if (!ctrlLocked) ctrlActive = false
+        if (!altLocked) altActive = false
+        if (!shiftLocked) shiftActive = false
+    }
+
+    /**
+     * Full reset: clears all active AND locked states.
+     * Called when the keyboard is hidden to ensure a clean slate on reopen.
+     */
+    fun resetAll() {
+        ctrlActive = false
+        altActive = false
+        shiftActive = false
+        ctrlLocked = false
+        altLocked = false
+        shiftLocked = false
+    }
+
+    /**
+     * Map common ASCII code points to Android KEYCODE_* constants.
+     */
+    fun codePointToKeyCode(codePoint: Int): Int {
+        return when {
+            codePoint in 'a'.code..'z'.code -> KeyEvent.KEYCODE_A + (codePoint - 'a'.code)
+            codePoint in 'A'.code..'Z'.code -> KeyEvent.KEYCODE_A + (codePoint - 'A'.code)
+            codePoint in '0'.code..'9'.code -> KeyEvent.KEYCODE_0 + (codePoint - '0'.code)
+            codePoint == ' '.code -> KeyEvent.KEYCODE_SPACE
+            codePoint == '.'.code -> KeyEvent.KEYCODE_PERIOD
+            codePoint == ','.code -> KeyEvent.KEYCODE_COMMA
+            codePoint == '/'.code -> KeyEvent.KEYCODE_SLASH
+            codePoint == '\\'.code -> KeyEvent.KEYCODE_BACKSLASH
+            codePoint == '-'.code -> KeyEvent.KEYCODE_MINUS
+            codePoint == '='.code -> KeyEvent.KEYCODE_EQUALS
+            codePoint == '['.code -> KeyEvent.KEYCODE_LEFT_BRACKET
+            codePoint == ']'.code -> KeyEvent.KEYCODE_RIGHT_BRACKET
+            codePoint == ';'.code -> KeyEvent.KEYCODE_SEMICOLON
+            codePoint == '\''.code -> KeyEvent.KEYCODE_APOSTROPHE
+            codePoint == '`'.code -> KeyEvent.KEYCODE_GRAVE
+            codePoint == '\t'.code -> KeyEvent.KEYCODE_TAB
+            codePoint == '\n'.code -> KeyEvent.KEYCODE_ENTER
+            else -> KeyEvent.KEYCODE_UNKNOWN
+        }
+    }
+}
+
+val CodingTabAction = Action(
+    icon = R.drawable.ic_coding_tab,
+    name = R.string.action_coding_tab_title,
+    simplePressImpl = { manager, _ ->
+        val meta = CodingModifierState.getMetaState()
+        manager.sendKeyEvent(KeyEvent.KEYCODE_TAB, meta)
+        CodingModifierState.consumeModifiers()
+    },
+    windowImpl = null,
+)
+
+val CodingCtrlAction = Action(
+    icon = R.drawable.ic_coding_ctrl,
+    name = R.string.action_coding_ctrl_title,
+    simplePressImpl = { _, _ ->
+        if (CodingModifierState.ctrlLocked) {
+            // Unlock and deactivate
+            CodingModifierState.ctrlLocked = false
+            CodingModifierState.ctrlActive = false
+        } else {
+            // Toggle one-shot
+            CodingModifierState.ctrlActive = !CodingModifierState.ctrlActive
+        }
+    },
+    windowImpl = null,
+)
+
+val CodingAltAction = Action(
+    icon = R.drawable.ic_coding_alt,
+    name = R.string.action_coding_alt_title,
+    simplePressImpl = { _, _ ->
+        if (CodingModifierState.altLocked) {
+            // Unlock and deactivate
+            CodingModifierState.altLocked = false
+            CodingModifierState.altActive = false
+        } else {
+            // Toggle one-shot
+            CodingModifierState.altActive = !CodingModifierState.altActive
+        }
+    },
+    windowImpl = null,
+)
+
+val CodingSlashAction = Action(
+    icon = R.drawable.ic_coding_slash,
+    name = R.string.action_coding_slash_title,
+    simplePressImpl = { manager, _ ->
+        val meta = CodingModifierState.getMetaState()
+        if (meta != 0) {
+            manager.sendKeyEvent(KeyEvent.KEYCODE_SLASH, meta)
+            CodingModifierState.consumeModifiers()
+        } else {
+            manager.typeText("/")
+        }
+    },
+    windowImpl = null,
+)
+
+val CodingDashAction = Action(
+    icon = R.drawable.ic_coding_dash,
+    name = R.string.action_coding_dash_title,
+    simplePressImpl = { manager, _ ->
+        val meta = CodingModifierState.getMetaState()
+        if (meta != 0) {
+            manager.sendKeyEvent(KeyEvent.KEYCODE_MINUS, meta)
+            CodingModifierState.consumeModifiers()
+        } else {
+            manager.typeText("-")
+        }
+    },
+    windowImpl = null,
+)
+
+val CodingEscAction = Action(
+    icon = R.drawable.ic_coding_esc,
+    name = R.string.action_coding_esc_title,
+    simplePressImpl = { manager, _ ->
+        val meta = CodingModifierState.getMetaState()
+        manager.sendKeyEvent(KeyEvent.KEYCODE_ESCAPE, meta)
+        CodingModifierState.consumeModifiers()
+    },
+    windowImpl = null,
+)
+
+val CodingShiftAction = Action(
+    icon = R.drawable.ic_coding_shift,
+    name = R.string.action_coding_shift_title,
+    simplePressImpl = { _, _ ->
+        if (CodingModifierState.shiftLocked) {
+            // Unlock and deactivate
+            CodingModifierState.shiftLocked = false
+            CodingModifierState.shiftActive = false
+        } else {
+            // Toggle one-shot
+            CodingModifierState.shiftActive = !CodingModifierState.shiftActive
+        }
+    },
+    windowImpl = null,
+)
+
+/**
+ * Toggle action for the coding bar. Can be assigned to favorites or the action key
+ * left of the spacebar. Pressing it toggles the coding bar on/off.
+ */
+val CodingBarAction = Action(
+    icon = R.drawable.ic_coding_bar,
+    name = R.string.action_coding_bar_title,
+    simplePressImpl = { manager, _ ->
+        val context = manager.getContext()
+        val current = context.getSettingBlocking(CodingBarDisplayedSetting)
+        context.setSettingBlocking(CodingBarDisplayedSetting.key, !current)
+    },
+    windowImpl = null,
+    shownInEditor = true,
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
@@ -40,7 +40,15 @@ val AllActionsMap = mapOf(
     "down" to ArrowDownAction,
     "left" to ArrowLeftAction,
     "right" to ArrowRightAction,
-    "font_typer" to FontTyperAction
+    "font_typer" to FontTyperAction,
+    "coding_tab" to CodingTabAction,
+    "coding_ctrl" to CodingCtrlAction,
+    "coding_alt" to CodingAltAction,
+    "coding_slash" to CodingSlashAction,
+    "coding_dash" to CodingDashAction,
+    "coding_esc" to CodingEscAction,
+    "coding_shift" to CodingShiftAction,
+    "coding_bar" to CodingBarAction
 )
 
 val ActionToId = AllActionsMap.entries.associate { it.value to it.key }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -147,6 +147,11 @@ val ActionBarDisplayedSetting = SettingsKey(
     true
 )
 
+val CodingBarDisplayedSetting = SettingsKey(
+    booleanPreferencesKey("enable_coding_bar"),
+    false
+)
+
 val InlineAutofillSetting = SettingsKey(
     booleanPreferencesKey("inline_autofill"),
     true
@@ -781,6 +786,14 @@ val KeyboardSettingsMenu = UserSettingsMenu(
             setting = ActionBarDisplayedSetting,
             icon = {
                 Icon(painterResource(id = R.drawable.more_horizontal), contentDescription = null)
+            }
+        ),
+        userSettingToggleDataStore(
+            title = R.string.keyboard_settings_show_coding_bar,
+            subtitle = R.string.keyboard_settings_show_coding_bar_subtitle,
+            setting = CodingBarDisplayedSetting,
+            icon = {
+                Icon(painterResource(id = R.drawable.ic_coding_bar), contentDescription = null)
             }
         ),
         userSettingToggleDataStore(


### PR DESCRIPTION
Adds a new "Coding Bar" that replaces the action/suggestions bar when enabled, providing shortcut buttons commonly needed for coding and terminal emulator use: TAB, CTRL, ALT, SHIFT, /, -, and ESC.

Modifier keys (CTRL, ALT, SHIFT) support two modes:
- Single press: one-shot activation, consumed after the next key press
- Long press: locked mode, stays active across multiple key presses until explicitly unlocked or the keyboard is hidden

The coding bar is toggleable via Settings > Keyboard & Typing and can also be assigned as a keyboard action.