### PR TITLE
Add small vibration when the MoreKeys Panel opens

### DIFF
--- a/java/src/org/futo/inputmethod/keyboard/MainKeyboardView.java
+++ b/java/src/org/futo/inputmethod/keyboard/MainKeyboardView.java
@@ -645,6 +645,12 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
 
     @Override
     public void onShowMoreKeysPanel(final MoreKeysPanel panel) {
+        // Haptic feedback on popup open
+        if (settingsValues.mVibrateOn) {
+            AudioAndHapticFeedbackManager.getInstance();
+            feedbackManager.vibrate(5);
+        }
+
         locatePreviewPlacerView();
         // Dismiss another {@link MoreKeysPanel} that may be being showed.
         onDismissMoreKeysPanel();


### PR DESCRIPTION
Add haptic feedback when opening more-keys popup

Feature: Implements #1550
Summary

This PR adds haptic feedback when the more-keys popup (shown on long-press for accents, symbols, etc.) is opened. The feedback uses the existing "Vibrate on keypress" setting, so users who have vibration enabled will now also get a short vibration when the popup appears.

Details:
- Haptic feedback is triggered in MainKeyboardView.onShowMoreKeysPanel(), using the same vibration manager as regular keypresses.
- The vibration duration is set to a short value (5ms), consistent with other feedback in the app.

Motivation

This improves the user experience for those accustomed to haptic feedback on popups (e.g., from Microsoft SwiftKey), providing a more responsive and tactile feel.

---

This is my first PR to a public project, If i need to change anything, please let me know :)

Closes #1550.