### PR TITLE
feat: support localehints hints when provided for textviews

### DIFF
--- a/java/res/values/strings.xml
+++ b/java/res/values/strings.xml
@@ -77,6 +77,13 @@
     <!-- Description for "next word suggestion" option. This displays suggestions even when there is no input, based on the previous word. -->
     <string name="bigram_prediction_summary">Use the previous word in making suggestions</string>
 
+    <!-- Title for auto-switch language setting -->
+    <string name="auto_switch_language_title">Auto-switch language</string>
+    <!-- Subtitle for auto-switch language setting -->
+    <string name="auto_switch_language_subtitle">Automatically switch to a matching language if the text field requests it (e.g. Translate)</string>
+    <!-- Title for advanced language settings section -->
+    <string name="language_settings_advanced_options">Advanced options</string>
+
     <!-- Title for input language selection screen -->
     <string name="language_selection_title">Languages</string>
 

--- a/java/src/org/futo/inputmethod/latin/InputAttributes.java
+++ b/java/src/org/futo/inputmethod/latin/InputAttributes.java
@@ -20,6 +20,7 @@ import static org.futo.inputmethod.latin.common.Constants.ImeOption.NO_FLOATING_
 import static org.futo.inputmethod.latin.common.Constants.ImeOption.NO_MICROPHONE;
 import static org.futo.inputmethod.latin.common.Constants.ImeOption.NO_MICROPHONE_COMPAT;
 
+import android.os.LocaleList;
 import android.text.InputType;
 import android.util.Log;
 import android.view.inputmethod.EditorInfo;
@@ -56,6 +57,8 @@ public final class InputAttributes {
     final public Locale mLocaleOverride;
     @Nullable
     final public String mLayoutOverride;
+    @Nullable
+    final public LocaleList mHintLocales;
 
     /**
      * Whether the floating gesture preview should be disabled. If true, this should override the
@@ -111,6 +114,7 @@ public final class InputAttributes {
             mIsWebField = false;
             mLocaleOverride = null;
             mLayoutOverride = null;
+            mHintLocales = null;
             return;
         }
         // inputClass == InputType.TYPE_CLASS_TEXT
@@ -191,6 +195,7 @@ public final class InputAttributes {
         }
 
         mLayoutOverride = privateImeOptions.get("org.futo.inputmethod.latin.ForceLayout");
+        mHintLocales = editorInfo.hintLocales;
     }
 
     public boolean isTypeNull() {

--- a/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
+++ b/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
@@ -343,7 +343,9 @@ public class LatinIMELegacy implements KeyboardActionListener,
     }
 
     void onStartInputInternal(final EditorInfo editorInfo, final boolean restarting) {
-
+        // Refresh InputAttributes even when restarting in the same field. Some apps
+        // (e.g Translate) update hintLocales but not inputType, leading to out of date hintLocales
+        loadSettings();
     }
 
     public void updateMainKeyboardViewSettings() {

--- a/java/src/org/futo/inputmethod/latin/settings/Settings.java
+++ b/java/src/org/futo/inputmethod/latin/settings/Settings.java
@@ -145,6 +145,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final int DEFAULT_ALT_SPACES_MODE = SPACES_MODE_ALL;
 
+    public static final String PREF_AUTO_SWITCH_LANGUAGE = "pref_auto_switch_language";
+
     // Emoji
     public static final String PREF_EMOJI_RECENT_KEYS = "emoji_recent_keys";
     public static final String PREF_EMOJI_CATEGORY_LAST_TYPED_ID = "emoji_category_last_typed_id";

--- a/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
@@ -106,7 +106,8 @@ public class SettingsValues {
     public final int mBackspaceMode;
     public final int mNumberRowMode;
     public final int mAltSpacesMode;
-
+    public final boolean mAutoSwitchLanguage;
+ 
     // From the input box
     @Nonnull
     public final InputAttributes mInputAttributes;
@@ -201,9 +202,10 @@ public class SettingsValues {
                 prefs.getInt(Settings.PREF_NUMBER_ROW_MODE, Settings.NUMBER_ROW_MODE_DEFAULT)
                 : Settings.NUMBER_ROW_MODE_DEFAULT;
         mAltSpacesMode = prefs.getInt(Settings.PREF_ALT_SPACES_MODE, Settings.DEFAULT_ALT_SPACES_MODE);
+        mAutoSwitchLanguage = prefs.getBoolean(Settings.PREF_AUTO_SWITCH_LANGUAGE, false);
 
         mShouldShowLxxSuggestionUi = Settings.SHOULD_SHOW_LXX_SUGGESTION_UI
-                && prefs.getBoolean(DebugSettings.PREF_SHOULD_SHOW_LXX_SUGGESTION_UI, true);
+               && prefs.getBoolean(DebugSettings.PREF_SHOULD_SHOW_LXX_SUGGESTION_UI, true);
         // Compute other readable settings
         mKeyLongpressTimeout = Settings.readKeyLongpressTimeout(prefs, res);
         mKeypressVibrationDuration = Settings.readKeypressVibrationDuration(prefs, res);

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
@@ -52,6 +52,7 @@ import org.futo.inputmethod.latin.MultilingualBucketSetting
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.Subtypes
 import org.futo.inputmethod.latin.SubtypesSetting
+import org.futo.inputmethod.latin.settings.Settings
 import org.futo.inputmethod.latin.uix.FileKind
 import org.futo.inputmethod.latin.uix.ResourceHelper
 import org.futo.inputmethod.latin.uix.getSetting
@@ -66,6 +67,7 @@ import org.futo.inputmethod.latin.uix.settings.pages.modelmanager.openModelImpor
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
+import org.futo.inputmethod.latin.uix.settings.userSettingToggleSharedPrefs
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.uix.theme.UixThemeWrapper
 import org.futo.inputmethod.latin.uix.theme.presets.DynamicDarkTheme
@@ -507,6 +509,16 @@ val LanguageSettingsTop = listOf(
         navigateTo = "addLanguage",
     )
 )
+
+val LanguageSettingsToggles = listOf(
+    userSettingToggleSharedPrefs(
+        title = R.string.auto_switch_language_title,
+        subtitle = R.string.auto_switch_language_subtitle,
+        key = Settings.PREF_AUTO_SWITCH_LANGUAGE,
+        default = { false }
+    )
+)
+
 val LanguageSettingsBottom = listOf(
     userSettingNavigationItem(
         title = R.string.language_settings_import_resource_from_file,
@@ -748,6 +760,14 @@ fun LanguagesScreen(navController: NavHostController = rememberNavController()) 
             ScreenTitle(stringResource(R.string.language_settings_other_options))
         }
         items(LanguageSettingsBottom) {
+            it.component()
+        }
+
+        item {
+            ScreenTitle(stringResource(R.string.language_settings_advanced_options))
+        }
+
+        items(LanguageSettingsToggles) {
             it.component()
         }
     }

--- a/tests/src/org/futo/inputmethod/latin/InputAttributesTests.java
+++ b/tests/src/org/futo/inputmethod/latin/InputAttributesTests.java
@@ -1,0 +1,29 @@
+package org.futo.inputmethod.latin;
+
+import android.os.LocaleList;
+import android.view.inputmethod.EditorInfo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InputAttributesTests {
+
+    @Test
+    public void testHintLocales() {
+        final EditorInfo editorInfo = mock(EditorInfo.class);
+        final LocaleList localeList = new LocaleList(new Locale("en", "US"), new Locale("ja", "JP"));
+        when(editorInfo.getHintLocales()).thenReturn(localeList);
+
+        final InputAttributes inputAttributes = new InputAttributes(editorInfo, false, "");
+
+        assertEquals(localeList, inputAttributes.mHintLocales);
+    }
+}


### PR DESCRIPTION
### Intention
Moving to FUTO from gboard one of the features I miss the most is auto keyboard language switching. For example if I am in google translate and I am translating japanese -> english, when I click on the japanese input box the keyboard automatically pulls up my last used JP keyboard format. If I click the "swap language" button that flips it to english -> japanese, the keyboard layout swaps to english from japanese automatically. 

Android allows preferred locales to be hinted at within textViews https://developer.android.com/reference/android/widget/TextView#setImeHintLocales(android.os.LocaleList) . This is up to the app to implement, so it is not guaranteed the app sets them. However when they are set, we may as well support them. 

### Implementation
I added a setting under a new Advanced Settings category in the language settings. If enabled this will allow the keyboard to swap to a preferred language locale IF one is supplied, AND the user has that locale enabled.  
Default: false  

When we start the keyboard we run a check on the inputAttribute hints, our current selected locale and all available. If our current locale is not in the provided hints AND we find a suitable on in our enabled locales we swap to that keyboard layout. 

There were a few workarounds I had to do, each is explained with a comment in the code. I am not a regular android dev (only did a little back in the android 4.4/5 days) so if I am doing anything not in best practices please let me know and I will be happy to refactor. 


### Tests  
The instrumentation tests seem to be broken. When I try to run them locally I was getting some errors around main thread execution of getService.onCreate(), and more around some XML when I updated to run onCreate() on the main thread. This may just be something I have setup incorrectly. If that is fixable please LMK. 

Because of this, for now I added a unit test for parsing the hints into our inputAttributes. 

### Device testing
I built these changes in a debug APK and loaded it onto my personal phone. I verified that the intended automatic language switching in Translate did work as intended. I tried with several languages and language pairs. 

### AI Disclaimer
It is a hot topic right now in OSS about AI slop PRs. I feel like one good thing we can all do to respect maintainers time is give a disclaimer at the minimum. Since I am new to the codebase I used some locally running AI models to help me trace and search through the code and learn the relevant things I was touching. AI generated ~30% of the code in this PR, 100% of that was reviewed by me and understood before accepting. 
  
  
Thanks for your time. 