### PR TITLE
Add rowSpan support to keyboard layout engine

### DIFF
--- a/java/src/org/futo/inputmethod/v2keyboard/BaseKey.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/BaseKey.kt
@@ -215,7 +215,13 @@ data class KeyAttributes(
      * flicking in all directions, rather it just triggers the morekey popup. Specifying this will
      * implicitly add the key as the first element in morekeys (may be broken with fixedColumnOrder)
      */
-    val fastMoreKeys: Boolean? = null
+    val fastMoreKeys: Boolean? = null,
+
+    /**
+     * Number of rows this key spans vertically. Defaults to 1.
+     * When set to a value > 1, the key will visually and functionally span multiple rows.
+     */
+    val rowSpan: Int? = null
 ) {
     fun getEffectiveAttributes(row: Row, keyboard: Keyboard, extraAttrs: List<KeyAttributes> = emptyList()): KeyAttributes {
         val attrs = if(row.isBottomRow) {
@@ -243,7 +249,8 @@ data class KeyAttributes(
             labelFlags          = resolve(attrs) { it.labelFlags         },
             repeatableEnabled   = resolve(attrs) { it.repeatableEnabled  },
             shiftable           = resolve(attrs) { it.shiftable          },
-            fastMoreKeys        = resolve(attrs) { it.fastMoreKeys       }
+            fastMoreKeys        = resolve(attrs) { it.fastMoreKeys       },
+            rowSpan             = resolve(attrs) { it.rowSpan            }
         )
     }
 
@@ -260,7 +267,8 @@ data class KeyAttributes(
             labelFlags          = resolve(attrs) { it.labelFlags         },
             repeatableEnabled   = resolve(attrs) { it.repeatableEnabled  },
             shiftable           = resolve(attrs) { it.shiftable          },
-            fastMoreKeys        = resolve(attrs) { it.fastMoreKeys       }
+            fastMoreKeys        = resolve(attrs) { it.fastMoreKeys       },
+            rowSpan             = resolve(attrs) { it.rowSpan            }
         )
     }
 }
@@ -280,7 +288,8 @@ val DefaultKeyAttributes = KeyAttributes(
     labelFlags          = LabelFlags(autoXScale = true),
     repeatableEnabled   = false,
     shiftable           = true,
-    fastMoreKeys        = false
+    fastMoreKeys        = false,
+    rowSpan             = 1
 )
 
 
@@ -437,7 +446,8 @@ data class BaseKey(
             countsToKeyCoordinate = moreKeyMode.autoNumFromCoord && moreKeyMode.autoSymFromCoord,
             hint = hint ?: "",
             labelFlags = attributes.labelFlags?.getValue() ?: 0,
-            fastLongPress = attributes.fastMoreKeys == true
+            fastLongPress = attributes.fastMoreKeys == true,
+            rowSpan = attributes.rowSpan ?: 1
         )
     }
 
@@ -625,7 +635,8 @@ class GapKey(val attributes: KeyAttributes = KeyAttributes()) : AbstractKey {
             moreKeyFlags = 0,
             countsToKeyCoordinate = moreKeyMode.autoNumFromCoord && moreKeyMode.autoSymFromCoord,
             hint = "",
-            labelFlags = 0
+            labelFlags = 0,
+            rowSpan = 1
         )
     }
 }

--- a/java/src/org/futo/inputmethod/v2keyboard/KeyData.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/KeyData.kt
@@ -95,4 +95,5 @@ data class ComputedKeyData(
     val labelFlags: Int,
     val flick: ComputedFlickData? = null,
     val fastLongPress: Boolean = false,
+    val rowSpan: Int = 1
 )

--- a/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
@@ -23,7 +23,7 @@ val EPS = 1e-5.toFloat()
 // ___z x c v b n m___
 // ^^^ gap     gap ^^^
 sealed class LayoutEntry(val widthPx: Float) {
-    class Key(val data: ComputedKeyData, widthPx: Float) : LayoutEntry(widthPx)
+    class Key(val data: ComputedKeyData, widthPx: Float, val rowSpan: Int = 1, val heightOverride: Float? = null) : LayoutEntry(widthPx)
     class Gap(widthPx: Float): LayoutEntry(widthPx)
 }
 
@@ -335,7 +335,7 @@ data class LayoutEngine(
                             entry.widthPx + widthPerKey
                         } else {
                             widthPerKey
-                        })
+                        }, rowSpan = entry.rowSpan, heightOverride = entry.heightOverride)
                     } else {
                         entry
                     }
@@ -354,7 +354,7 @@ data class LayoutEngine(
         splittable: Boolean
     ): LayoutRow {
         val computedRow = computedRowWithoutWidths.map { key ->
-            LayoutEntry.Key(key.data, widths[key.data.width]!!)
+            LayoutEntry.Key(key.data, widths[key.data.width]!!, key.rowSpan)
         }
 
         val totalRowWidth = computedRow.sumOf { it.widthPx.toDouble() }.toFloat()
@@ -420,7 +420,7 @@ data class LayoutEngine(
                         regularColumn += 1
                     }
 
-                    LayoutEntry.Key(data, widthPx = -1.0f)
+                    LayoutEntry.Key(data, widthPx = -1.0f, rowSpan = data.rowSpan)
                 }
             }.let {
                 if (regularColumn > 0) {
@@ -474,7 +474,52 @@ data class LayoutEngine(
             )
         }
 
-        return alignForSplitLayout(computedRowWithWidths)
+        // Post-process rowSpan: set heightOverride on spanning keys and replace
+        // corresponding entries in subsequent rows with gaps
+        val rowSpanProcessed = computedRowWithWidths.toMutableList()
+        for (rowIdx in rowSpanProcessed.indices) {
+            val row = rowSpanProcessed[rowIdx]
+            val newEntries = row.entries.mapIndexed { entryIdx, entry ->
+                if (entry is LayoutEntry.Key && entry.rowSpan > 1) {
+                    // Accumulate height from this row and the next (rowSpan - 1) rows
+                    var totalHeight = row.height
+                    for (spanOffset in 1 until entry.rowSpan) {
+                        val targetRowIdx = rowIdx + spanOffset
+                        if (targetRowIdx < rowSpanProcessed.size) {
+                            totalHeight += rowSpanProcessed[targetRowIdx].height
+
+                            // Replace the matching entry in the subsequent row with a gap
+                            val targetRow = rowSpanProcessed[targetRowIdx]
+                            val targetEntries = targetRow.entries.toMutableList()
+
+                            // Find the entry at the same horizontal position
+                            var currentX = 0.0f
+                            var sourceX = 0.0f
+                            for (j in 0 until entryIdx) {
+                                sourceX += row.entries[j].widthPx
+                            }
+
+                            for (j in targetEntries.indices) {
+                                if (Math.abs(currentX - sourceX) < 1.0f &&
+                                    Math.abs(targetEntries[j].widthPx - entry.widthPx) < 1.0f) {
+                                    targetEntries[j] = LayoutEntry.Gap(targetEntries[j].widthPx)
+                                    break
+                                }
+                                currentX += targetEntries[j].widthPx
+                            }
+
+                            rowSpanProcessed[targetRowIdx] = targetRow.copy(entries = targetEntries)
+                        }
+                    }
+                    LayoutEntry.Key(entry.data, entry.widthPx, entry.rowSpan, heightOverride = totalHeight)
+                } else {
+                    entry
+                }
+            }
+            rowSpanProcessed[rowIdx] = row.copy(entries = newEntries)
+        }
+
+        return alignForSplitLayout(rowSpanProcessed)
     }
 
     private fun mergeDuplicates(row: List<LayoutEntry>): List<LayoutEntry> {
@@ -489,7 +534,8 @@ data class LayoutEngine(
                     val lastVal = acc.removeAt(acc.size - 1)
                     acc.add(LayoutEntry.Key(
                         data = curr.data,
-                        widthPx = last.widthPx + curr.widthPx
+                        widthPx = last.widthPx + curr.widthPx,
+                        rowSpan = curr.rowSpan
                     ))
                 } else {
                     acc.add(curr)
@@ -529,8 +575,8 @@ data class LayoutEngine(
                 if(data.repeatable) { KeyConsts.ACTION_FLAGS_IS_REPEATABLE } else { 0 }
 
         val verticalGapForKey = when {
-            keyboard.rowHeightMode.clampHeight && height > layoutParams.standardRowHeight ->
-                height - layoutParams.standardRowHeight
+            keyboard.rowHeightMode.clampHeight && height > data.rowSpan * layoutParams.standardRowHeight ->
+                height - data.rowSpan * layoutParams.standardRowHeight
 
             else ->
                 0.0
@@ -637,7 +683,8 @@ data class LayoutEngine(
                     val leftGap = if(i < row.size / 2 && !entry.data.anchored) { row.getOrNull(i - 1) as? LayoutEntry.Gap } else { null }
                     val rightGap = if(i >= row.size / 2 && !entry.data.anchored) { row.getOrNull(i + 1) as? LayoutEntry.Gap } else { null }
 
-                    addKey(idx, colNum, entry.data, currentX.roundToInt(), y, entry.widthPx.roundToInt(), height, leftGap, rightGap)
+                    val keyHeight = entry.heightOverride?.roundToInt() ?: height
+                    addKey(idx, colNum, entry.data, currentX.roundToInt(), y, entry.widthPx.roundToInt(), keyHeight, leftGap, rightGap)
 
                     // i != colNum because of Gap entries
                     colNum += 1


### PR DESCRIPTION
Allow keys to visually and functionally span multiple rows by adding a rowSpan attribute. The layout engine accumulates row heights for spanning keys, sets a heightOverride, and converts overlapping entries in subsequent rows to gaps. The clampHeight logic is adjusted to account for multi-row keys so they aren't incorrectly shrunk.

This is needed for the ClearFlow layout where space keys on each side should span two adjacent letter rows as single tall keys.