### PR TITLE
KeyboardLayoutPreview.kt: Changed bottomActionKey to 0

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/KeyboardLayoutPreview.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/KeyboardLayoutPreview.kt
@@ -109,7 +109,7 @@ fun KeyboardLayoutPreview(id: String, width: Dp = 172.dp, locale: Locale? = null
                     numberRow = false,
                     arrowRow = false,
                     alternativePeriodKey = false,
-                    bottomActionKey = null,
+                    bottomActionKey = 0,
                     useLocalNumbers = true,
                     numberRowMode = 0
                 )


### PR DESCRIPTION
Passing 0 (the emoji action index) ensures the action key renders in all layout previews - such as ClearFlow where it is present on the second row.