### PR TITLE
add temporary `Sticky altPages` toggle to developer settings

### DIFF
--- a/java/src/org/futo/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/java/src/org/futo/inputmethod/keyboard/KeyboardSwitcher.java
@@ -66,6 +66,7 @@ public final class KeyboardSwitcher implements SwitchActions {
     private LatinIMELegacy mLatinIMELegacy;
     private RichInputMethodManager mRichImm;
     private boolean mIsHardwareAcceleratedDrawingEnabled;
+    private boolean mStickyAltPagesEnabled;
 
     public KeyboardState mState;
 
@@ -94,7 +95,15 @@ public final class KeyboardSwitcher implements SwitchActions {
         mLatinIMELegacy = latinImeLegacy;
         mRichImm = RichInputMethodManager.getInstance();
         mState = new KeyboardState(this);
+        mState.setStickyAltPagesEnabled(mStickyAltPagesEnabled);
         mIsHardwareAcceleratedDrawingEnabled = true;
+    }
+
+    public void setStickyAltPagesEnabled(final boolean enabled) {
+        mStickyAltPagesEnabled = enabled;
+        if (mState != null) {
+            mState.setStickyAltPagesEnabled(enabled);
+        }
     }
 
     public void updateKeyboardTheme(@NonNull Context displayContext) {

--- a/java/src/org/futo/inputmethod/keyboard/internal/KeyboardState.kt
+++ b/java/src/org/futo/inputmethod/keyboard/internal/KeyboardState.kt
@@ -199,9 +199,17 @@ class KeyboardState(private val switchActions: SwitchActions) {
     private var prefersNumberLayout = false
     private var currentLayoutSet = ""
     private var preferredAlphabetKind: Pair<String, Int> = "" to 0
+    private var stickyAltPagesEnabled = false
 
     private val debugState: String
         get() = "Layout $currentLayout, alphabetShiftState: $alphabetShiftState, shiftKeyState $shiftKeyState, symbolKeyState $symbolKeyState"
+
+    fun setStickyAltPagesEnabled(enabled: Boolean) {
+        stickyAltPagesEnabled = enabled
+    }
+
+    private fun isStickyAltPage(page: KeyboardLayoutPage = currentLayout.page): Boolean =
+        stickyAltPagesEnabled && page.altIdx != null
 
     private fun setLayout(layout: KeyboardLayoutElement) {
         currentLayout = layout
@@ -508,6 +516,9 @@ class KeyboardState(private val switchActions: SwitchActions) {
 
         // Otherwise, unshift the layout if it's not locked
         if(!currentLayout.page.locked) {
+            if(isStickyAltPage()) {
+                return
+            }
             toggleShift(false)
             return
         }

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -83,6 +83,7 @@ import org.futo.inputmethod.latin.uix.getSettingFlow
 import org.futo.inputmethod.latin.uix.isDirectBootUnlocked
 import org.futo.inputmethod.latin.uix.safeKeyboardPadding
 import org.futo.inputmethod.latin.uix.setSetting
+import org.futo.inputmethod.latin.uix.settings.pages.StickyAltPagesSetting
 import org.futo.inputmethod.latin.uix.theme.ThemeOption
 import org.futo.inputmethod.latin.uix.theme.applyWindowColors
 import org.futo.inputmethod.latin.uix.theme.getThemeOption
@@ -390,6 +391,9 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
 
         imeManager.onCreate()
         latinIMELegacy.onCreate()
+        latinIMELegacy.mKeyboardSwitcher.setStickyAltPagesEnabled(
+            getSettingBlocking(StickyAltPagesSetting)
+        )
 
         scheduleUpdateCheckingJob(this)
         launchJob { uixManager.showUpdateNoticeIfNeeded() }
@@ -421,6 +425,12 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
                         }
                     }
                 }
+        }
+
+        launchJob {
+            getSettingFlow(StickyAltPagesSetting).collect {
+                latinIMELegacy.mKeyboardSwitcher.setStickyAltPagesEnabled(it)
+            }
         }
 
         launchJob {

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/DevSettings.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/DevSettings.kt
@@ -59,6 +59,7 @@ import kotlin.system.exitProcess
 
 
 val IS_DEVELOPER = SettingsKey(booleanPreferencesKey("isDeveloperMode"), false)
+val StickyAltPagesSetting = SettingsKey(booleanPreferencesKey("stickyAltPages"), false)
 
 @OptIn(DebugOnly::class)
 @Composable
@@ -154,6 +155,7 @@ fun DeveloperScreen(navController: NavHostController = rememberNavController()) 
             style = NavigationItemStyle.Misc,
             navigate = { navController.navigate("devlayouteditor") }
         )
+        SettingToggleDataStore(title = "Sticky altPages", setting = StickyAltPagesSetting)
         NavigationItem(
             title = "Theme dev utility",
             style = NavigationItemStyle.Misc,


### PR DESCRIPTION
https://github.com/futo-org/futo-keyboard-layouts/issues/183

Disclaimer: Codex wrote this code, but it seems to work as intended, at least. This is only meant to be a temporary solution for now.