### PR TITLE
feat: Add non-staggered keyboard layout support

### DIFF
--- a/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
@@ -293,7 +293,16 @@ data class Keyboard(
     val autoShift: Boolean = true,
 
     val subKeyboards: Map<KeyboardLayoutKind, SubKeyboard> = emptyMap(),
-    val imeHint: String? = null
+    val imeHint: String? = null,
+
+    /**
+     * (optional) Whether keyboard rows use staggered (center-gapped) alignment.
+     * When true (default), rows with fewer keys than the widest row are centered with
+     * gaps on either side, matching the traditional staggered keyboard layout.
+     * When false, rows are left-aligned with no centering gaps, producing an
+     * ortholinear/grid-style layout.
+     */
+    val staggered: Boolean = true
 
 
     //val element: KeyboardElement = KeyboardElement.Alphabet,

--- a/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
@@ -360,7 +360,15 @@ data class LayoutEngine(
         val totalRowWidth = computedRow.sumOf { it.widthPx.toDouble() }.toFloat()
 
         val rowLayoutWidth = if(splittable) { layoutWidth } else { unsplitLayoutWidth }
-        val entries = mergeDuplicates(computedRow.addGap(rowLayoutWidth - totalRowWidth))
+        val entries = if(keyboard.staggered) {
+            mergeDuplicates(computedRow.addGap(rowLayoutWidth - totalRowWidth))
+        } else {
+            // Stretch keys to fill the entire row width (ortholinear/grid layout)
+            val extraPerKey = (rowLayoutWidth - totalRowWidth) / computedRow.size
+            computedRow.map { key ->
+                LayoutEntry.Key(key.data, key.widthPx + extraPerKey)
+            }
+        }
 
         return LayoutRow(
             entries = entries,


### PR DESCRIPTION
Add `staggered` boolean property to keyboard config to enable ortholinear/grid-style layouts. Include new QWERTY and QWERTZ non-staggered layout files and update mapping for all locales in https://github.com/futo-org/futo-keyboard-layouts/pull/270

Default staggered QUERTZ layout:
<img width="383" height="360" alt="Screenshot_20260313_121344_Samsung Notes(1)" src="https://github.com/user-attachments/assets/88ec6067-529d-44f2-88e1-cff3c191b65b" />

New non staggered QUERTZ layout with full width middle row:
<img width="379" height="360" alt="Screenshot_20260313_121258_Samsung Notes" src="https://github.com/user-attachments/assets/db00f95c-264c-4772-b6c0-e88b3d41644d" />

New layouts can be selected under Keyboard Layouts for your active languages:
<img width="426" height="890" alt="Screenshot_20260313_121401_FUTO Keyboard(1)" src="https://github.com/user-attachments/assets/899a2a53-6a0f-46e6-b31e-02e0d57981b5" />
