### PR TITLE
feat: Add compact suggestion bar option

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -470,6 +470,8 @@
     <string name="keyboard_settings_extra_layouts_subtitle">Configure additional layouts in the languages screen</string>
     <string name="keyboard_settings_show_suggestion_row">Show action/suggestions bar</string>
     <string name="keyboard_settings_show_suggestion_row_subtitle">Show the bar containing suggestions. Recommended to keep enabled</string>
+    <string name="keyboard_settings_compact_suggestion_bar">Compact suggestion bar</string>
+    <string name="keyboard_settings_compact_suggestion_bar_subtitle">Reduce the height of the suggestion bar and remove buttons from it</string>
     <string name="keyboard_settings_inline_autofill">Inline autofill</string>
     <string name="keyboard_settings_inline_autofill_subtitle">Display password manager autofill and auto-reply suggestions (provided by app) in suggestion bar</string>
     <string name="keyboard_settings_period_key">Quick period key</string>

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableFloatState
@@ -161,6 +162,17 @@ import kotlin.math.roundToInt
  */
 
 val ActionBarHeight = 40.dp
+val CompactActionBarHeight = 26.dp
+
+val SuggestionBarCompactSetting = SettingsKey(
+    booleanPreferencesKey("suggestion_bar_compact"),
+    false
+)
+
+val LocalSuggestionBarCompact = staticCompositionLocalOf { false }
+
+val currentActionBarHeight: Dp
+    @Composable get() = if (LocalSuggestionBarCompact.current) CompactActionBarHeight else ActionBarHeight
 
 val ActionBarScrollIndexSetting = SettingsKey(
     intPreferencesKey("action_bar_scroll_index"),
@@ -196,7 +208,6 @@ val suggestionStylePrimary = TextStyle(
     fontSize = 18.sp,
     lineHeight = 26.sp,
     letterSpacing = 0.5.sp,
-    //textAlign = TextAlign.Center
 )
 
 val suggestionStyleAlternative = TextStyle(
@@ -205,7 +216,22 @@ val suggestionStyleAlternative = TextStyle(
     fontSize = 18.sp,
     lineHeight = 26.sp,
     letterSpacing = 0.5.sp,
-    //textAlign = TextAlign.Center
+)
+
+val suggestionStylePrimaryCompact = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight.Medium,
+    fontSize = 14.sp,
+    lineHeight = 18.sp,
+    letterSpacing = 0.5.sp,
+)
+
+val suggestionStyleAlternativeCompact = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight.Normal,
+    fontSize = 14.sp,
+    lineHeight = 18.sp,
+    letterSpacing = 0.5.sp,
 )
 
 val suggestionStyleCandidateDescription = TextStyle(
@@ -315,9 +341,12 @@ fun RowScope.SuggestionItem(words: SuggestedWords, idx: Int, isPrimary: Boolean,
         else -> Modifier
     }
 
-    val textStyle = when(isAutocorrect) {
-        true -> suggestionStylePrimary
-        false -> suggestionStyleAlternative
+    val compact = LocalSuggestionBarCompact.current
+    val textStyle = when {
+        isAutocorrect && compact -> suggestionStylePrimaryCompact
+        isAutocorrect -> suggestionStylePrimary
+        compact -> suggestionStyleAlternativeCompact
+        else -> suggestionStyleAlternative
     }.copy(color = color).withCustomFont()
 
     Box(
@@ -787,13 +816,15 @@ fun ActionBar(
     val view = LocalView.current
     val context = LocalContext.current
 
+    val compact = LocalSuggestionBarCompact.current
+    val barHeight = if (compact) CompactActionBarHeight else ActionBarHeight
     val oldActionBar = useDataStore(OldStyleActionsBar)
 
-    val useDoubleHeight = isActionsExpanded && oldActionBar.value == false
+    val useDoubleHeight = isActionsExpanded && oldActionBar.value == false && !compact
 
     Column(Modifier
         .height(
-            ActionBarHeight * (if (useDoubleHeight) 2 else 1).let {
+            barHeight * (if (useDoubleHeight) 2 else 1).let {
                 if(needToUseExpandableSuggestionUi) {
                     it - 1
                 } else {
@@ -805,7 +836,7 @@ fun ActionBar(
             testTag = "ActionBar"
             testTagsAsResourceId = true
         }) {
-        if(isActionsExpanded && !oldActionBar.value) {
+        if(isActionsExpanded && !oldActionBar.value && !compact) {
             ActionSep()
 
             Surface(
@@ -827,30 +858,33 @@ fun ActionBar(
                 .weight(1.0f), color = actionBarColor()
         ) {
             Row(Modifier.safeKeyboardPadding()) {
-                ExpandActionsButton(isActionsExpanded) {
-                    toggleActionsExpanded()
+                if (!compact) {
+                    ExpandActionsButton(isActionsExpanded) {
+                        toggleActionsExpanded()
 
-                    keyboardManagerForAction?.performHapticAndAudioFeedback(
-                        Constants.CODE_TAB,
-                        view
-                    )
+                        keyboardManagerForAction?.performHapticAndAudioFeedback(
+                            Constants.CODE_TAB,
+                            view
+                        )
+                    }
                 }
 
-                if(oldActionBar.value && isActionsExpanded) {
+                if(oldActionBar.value && isActionsExpanded && !compact) {
                     Box(modifier = Modifier
                         .weight(1.0f)
                         .fillMaxHeight()) {
                         ActionItems(onActionActivated, onActionAltActivated)
                     }
                 } else {
-                    if (importantNotice != null) {
+                    if (importantNotice != null && !compact) {
                         ImportantNoticeView(importantNotice)
                     } else {
                         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
                             && inlineSuggestions.isNotEmpty()
+                            && !compact
                         ) {
                             InlineSuggestions(inlineSuggestions)
-                        } else if(quickClipState != null) {
+                        } else if(quickClipState != null && !compact) {
                             QuickClipView(quickClipState, onQuickClipDismiss)
                         } else if (words != null) {
                             SuggestionItems(
@@ -873,7 +907,7 @@ fun ActionBar(
                             Spacer(modifier = Modifier.weight(1.0f))
                         }
 
-                        if(inlineSuggestions.isEmpty()) {
+                        if(inlineSuggestions.isEmpty() && !compact) {
                             PinnedActionItems(onActionActivated, onActionAltActivated)
                         }
                     }
@@ -892,7 +926,7 @@ fun ActionWindowBar(
     onBack: () -> Unit,
     onExpand: () -> Unit
 ) {
-    Column(Modifier.height(ActionBarHeight)) {
+    Column(Modifier.height(currentActionBarHeight)) {
         ActionSep()
         Surface(
             modifier = Modifier
@@ -955,7 +989,7 @@ fun CollapsibleSuggestionsBar(
     words: SuggestedWords?,
     suggestionStripListener: SuggestionStripViewListener,
 ) {
-    Column(Modifier.height(ActionBarHeight)) {
+    Column(Modifier.height(currentActionBarHeight)) {
         ActionSep()
         Surface(
             modifier = Modifier
@@ -1215,7 +1249,7 @@ private fun RowScope.InlineCandidates(
                 }
             }
             itemsIndexed(wordList) { i, it ->
-                CandidateItem(Modifier.height(ActionBarHeight), it,
+                CandidateItem(Modifier.height(currentActionBarHeight), it,
                     listener = suggestionStripListener,
                     last = i == wordList.size-1,
                     width = with(LocalDensity.current) {
@@ -1335,7 +1369,7 @@ fun BoxScope.ActionBarWithExpandableCandidates(
 
     if(canShowSuggest) {
         Surface(
-            Modifier.fillMaxWidth().padding(0.dp, ActionBarHeight, 0.dp, 0.dp)
+            Modifier.fillMaxWidth().padding(0.dp, currentActionBarHeight, 0.dp, 0.dp)
                 .heightIn(max = with(density) { keyboardOffset?.intValue?.toDp() ?: 0.dp })
                 .safeKeyboardPadding()
         ) {
@@ -1343,7 +1377,7 @@ fun BoxScope.ActionBarWithExpandableCandidates(
                 listToRender ?: emptyList(),
                 itemMeasurer = { measureWord(density, widths, it) }
             ) { allocatedWidth, item, isLast ->
-                CandidateItem(Modifier.height(ActionBarHeight), item, listener = suggestionStripListener, width=with(density) { allocatedWidth.toDp()  }, last=isLast)
+                CandidateItem(Modifier.height(currentActionBarHeight), item, listener = suggestionStripListener, width=with(density) { allocatedWidth.toDp()  }, last=isLast)
             }
         }
     }
@@ -1353,7 +1387,7 @@ fun BoxScope.ActionBarWithExpandableCandidates(
                 testTag = "ActionBar"
                 testTagsAsResourceId = true
             }
-            .height(ActionBarHeight)
+            .height(currentActionBarHeight)
             .align(Alignment.TopCenter)
     ) {
         ActionSep()

--- a/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
@@ -322,7 +322,7 @@ object QuickClip {
 @Preview
 @Composable
 private fun PreviewQuickClips() {
-    Row(Modifier.height(ActionBarHeight)) {
+    Row(Modifier.height(currentActionBarHeight)) {
         QuickClipView(QuickClipState(
             texts = listOf(QuickClipItem(
                 kind = QuickClipKind.FullString,

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -132,6 +132,7 @@ import org.futo.inputmethod.latin.uix.settings.DataStoreCacheProvider
 import org.futo.inputmethod.latin.uix.settings.pages.ActionBarDisplayedSetting
 import org.futo.inputmethod.latin.uix.settings.pages.InlineAutofillSetting
 import org.futo.inputmethod.latin.uix.settings.useDataStore
+import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.theme.KeyboardSurfaceShaderBackground
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.uix.theme.UixThemeAuto
@@ -227,12 +228,13 @@ fun BoxScope.KeyboardBackground(
         shader != null -> KeyboardSurfaceShaderBackground(shader, modifier = Modifier.matchParentSize())
         image != null && rect != null -> {
             val navbarHeight = navBarHeight()
+            val actionBarHeightDp = currentActionBarHeight
             Canvas(Modifier.matchParentSize()) {
                 drawRect(colorScheme.keyboardSurface)
 
                 val fixedWidth = computedSize?.width?.toFloat() ?: size.width
                 val fixedHeight = when {
-                    (computedSize != null) -> computedSize.height + ActionBarHeight.toPx() + navbarHeight.toPx()
+                    (computedSize != null) -> computedSize.height + actionBarHeightDp.toPx() + navbarHeight.toPx()
                     else -> size.height
                 }
 
@@ -777,7 +779,7 @@ class UixManager(private val latinIME: LatinIME) {
                             currWindowActionWindow.value?.fixedWindowHeight ?: ((latinIME
                                 .getInputViewHeight()
                                 .toFloat() / heightDiv.toFloat()).toDp() +
-                                    if (actionsExpanded) ActionBarHeight else 0.dp)
+                                    if (actionsExpanded) currentActionBarHeight else 0.dp)
                         })
                         .safeKeyboardPadding()
                 ) {
@@ -1099,7 +1101,7 @@ class UixManager(private val latinIME: LatinIME) {
             Column(modifier = Modifier
                 .matchParentSize()
                 .absolutePadding(
-                    top = if (isActionsExpanded.value) ActionBarHeight else 0.dp
+                    top = if (isActionsExpanded.value) currentActionBarHeight else 0.dp
                 ), horizontalAlignment = when(size.direction) {
                 // Aligned opposite of the keyboard
                 OneHandedDirection.Left -> Alignment.End
@@ -1185,11 +1187,13 @@ class UixManager(private val latinIME: LatinIME) {
     private fun ProvidersAndWrapper(content: @Composable () -> Unit) {
         UixThemeWrapper(latinIME.colorScheme) {
             DataStoreCacheProvider {
+                val compactSuggestionBar = useDataStoreValue(SuggestionBarCompactSetting)
                 CompositionLocalProvider(
                     LocalManager provides keyboardManagerForAction,
                     LocalThemeProvider provides latinIME.getDrawableProvider(),
                     LocalLayoutDirection provides LayoutDirection.Ltr,
-                    LocalFoldingState provides foldingOptions.value
+                    LocalFoldingState provides foldingOptions.value,
+                    LocalSuggestionBarCompact provides compactSuggestionBar
                 ) {
                     Box(Modifier
                         .fillMaxSize()

--- a/java/src/org/futo/inputmethod/latin/uix/actions/EmojiAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/EmojiAction.kt
@@ -100,6 +100,7 @@ import org.futo.inputmethod.latin.uix.EmojiTracker.getRecentEmojis
 import org.futo.inputmethod.latin.uix.EmojiTracker.resetRecentEmojis
 import org.futo.inputmethod.latin.uix.EmojiTracker.useEmoji
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
+import org.futo.inputmethod.latin.uix.LocalSuggestionBarCompact
 import org.futo.inputmethod.latin.uix.PersistentActionState
 import org.futo.inputmethod.latin.uix.actions.emoji.EmojiItem
 import org.futo.inputmethod.latin.uix.actions.emoji.EmojiView
@@ -1011,6 +1012,11 @@ val EmojiAction = Action(
             @Composable
             override fun WindowTitleBar(rowScope: RowScope) {
                 val context = LocalContext.current
+                val compact = LocalSuggestionBarCompact.current
+                if(compact) {
+                    super.WindowTitleBar(rowScope)
+                    return
+                }
                 if(searching.value) {
                     with(rowScope) {
                         Surface(

--- a/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.Action
 import org.futo.inputmethod.latin.uix.ActionBarHeight
+import org.futo.inputmethod.latin.uix.currentActionBarHeight
 import org.futo.inputmethod.latin.uix.ActionWindow
 import org.futo.inputmethod.latin.uix.CloseResult
 import org.futo.inputmethod.latin.uix.TutorialMode
@@ -92,7 +93,7 @@ val KeyboardModeAction = Action(
             override fun WindowContents(keyboardShown: Boolean) {
                 val currMode = sizeCalculator.getSavedSettings().currentMode
                 Column {
-                    Row(Modifier.height(ActionBarHeight)) {
+                    Row(Modifier.height(currentActionBarHeight)) {
                         // Hide the back button in the resize tutorial
                         if(manager.getTutorialMode() != TutorialMode.ResizerTutorial) {
                             IconButton(onClick = {

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -96,6 +96,7 @@ import org.futo.inputmethod.latin.settings.toLongPressKeyLayoutItems
 import org.futo.inputmethod.latin.uix.AndroidTextInput
 import org.futo.inputmethod.latin.uix.BasicThemeProvider
 import org.futo.inputmethod.latin.uix.KeyHintsSetting
+import org.futo.inputmethod.latin.uix.SuggestionBarCompactSetting
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
 import org.futo.inputmethod.latin.uix.SHOW_EMOJI_SUGGESTIONS
 import org.futo.inputmethod.latin.uix.SettingsKey
@@ -783,6 +784,13 @@ val KeyboardSettingsMenu = UserSettingsMenu(
                 Icon(painterResource(id = R.drawable.more_horizontal), contentDescription = null)
             }
         ),
+        userSettingToggleDataStore(
+            title = R.string.keyboard_settings_compact_suggestion_bar,
+            subtitle = R.string.keyboard_settings_compact_suggestion_bar_subtitle,
+            setting = SuggestionBarCompactSetting,
+        ).copy(visibilityCheck = {
+            useDataStore(ActionBarDisplayedSetting).value
+        }),
         userSettingToggleDataStore(
             title = R.string.keyboard_settings_inline_autofill,
             subtitle = R.string.keyboard_settings_inline_autofill_subtitle,

--- a/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
@@ -26,6 +26,7 @@ import org.futo.inputmethod.latin.FoldStateProvider
 import org.futo.inputmethod.latin.LatinIME
 import org.futo.inputmethod.latin.settings.SettingsValues
 import org.futo.inputmethod.latin.uix.OldStyleActionsBar
+import org.futo.inputmethod.latin.uix.SuggestionBarCompactSetting
 import org.futo.inputmethod.latin.uix.SettingsKey
 import org.futo.inputmethod.latin.uix.UixManager
 import org.futo.inputmethod.latin.uix.getSetting
@@ -553,7 +554,8 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
     }
 
     fun calculateSuggestionBarHeightDp(): Float {
-        return 40.0f
+        val compact = context.getSetting(SuggestionBarCompactSetting) == true
+        return if (compact) 26.0f else 40.0f
     }
 
     fun calculateTotalActionBarHeightPx(): Int =


### PR DESCRIPTION
As someone who uses the dedicated numbers row, having another full sized suggestion bar row takes a lot of precious screen real-estate, so I've added an optional compact mode which reduces the height of suggestion bar and removes the expand and microphone input buttons.

 
<img width="397" height="360" alt="Screenshot_20260313_121231_Samsung Notes" src="https://github.com/user-attachments/assets/0f20c20d-f8d4-4291-9cec-c49f535c60de" />


Compact mode for suggestion bar can be turned on or off with a new toggle button:
<img width="277" height="580" alt="Screenshot_20260313_121201_FUTO Keyboard" src="https://github.com/user-attachments/assets/7a47b3e5-f04b-4927-a93d-56ffcf1da315" />