### PR TITLE
Hide split keyboard option for layouts that don't support it

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -144,6 +144,7 @@ import org.futo.inputmethod.updates.isManualUpdateTimeExpired
 import org.futo.inputmethod.updates.openManualUpdateCheck
 import org.futo.inputmethod.updates.retrieveSavedLastUpdateCheckResult
 import org.futo.inputmethod.v2keyboard.ComputedKeyboardSize
+import org.futo.inputmethod.v2keyboard.getPrimaryLayoutOverride
 import org.futo.inputmethod.v2keyboard.FloatingKeyboardSize
 import org.futo.inputmethod.v2keyboard.KeyboardSizingCalculator
 import org.futo.inputmethod.v2keyboard.OneHandedDirection
@@ -602,6 +603,11 @@ class UixManager(private val latinIME: LatinIME) {
     private val keyboardManagerForAction = UixActionKeyboardManager(this, latinIME)
 
     private var mainKeyboardHidden = mutableStateOf(false)
+
+    fun getCurrentLayoutName(): String =
+        getPrimaryLayoutOverride(latinIME.currentInputEditorInfo)
+            ?: latinIME.latinIMELegacy.mKeyboardSwitcher.keyboard?.mId?.mKeyboardLayoutSetName
+            ?: "qwerty"
 
     private var numSuggestionsSinceNotice = 0
     private var currentNotice: MutableState<ImportantNotice?> = mutableStateOf(null)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
@@ -133,13 +133,15 @@ val KeyboardModeAction = Action(
                             currMode == KeyboardMode.OneHanded
                         )
 
-                        KeyboardMode(
-                            R.drawable.keyboard_split,
-                            R.drawable.keyboard_split_fill_check,
-                            stringResource(R.string.action_keyboard_modes_split),
-                            sizeCalculator, KeyboardMode.Split,
-                            currMode == KeyboardMode.Split
-                        )
+                        if(sizeCalculator.doesCurrentLayoutSupportSplit()) {
+                            KeyboardMode(
+                                R.drawable.keyboard_split,
+                                R.drawable.keyboard_split_fill_check,
+                                stringResource(R.string.action_keyboard_modes_split),
+                                sizeCalculator, KeyboardMode.Split,
+                                currMode == KeyboardMode.Split
+                            )
+                        }
 
                         KeyboardMode(
                             R.drawable.keyboard_float,

--- a/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
@@ -292,6 +292,12 @@ data class Keyboard(
      */
     val autoShift: Boolean = true,
 
+    /**
+     * (optional) Whether the split keyboard mode should be offered for this layout. Set to false
+     * for layouts whose rows don't split well (e.g. due to rowSpan keys or unusual arrangements).
+     */
+    val supportsSplit: Boolean = true,
+
     val subKeyboards: Map<KeyboardLayoutKind, SubKeyboard> = emptyMap(),
     val imeHint: String? = null
 

--- a/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
@@ -394,6 +394,16 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
         currentMode = if(it.prefersSplit) KeyboardMode.Split else KeyboardMode.Regular
     ) }
 
+    fun doesCurrentLayoutSupportSplit(): Boolean {
+        val layoutName = uixManager.getCurrentLayoutName()
+        val layout = try {
+            LayoutManager.getLayout(context, layoutName)
+        } catch (e: Exception) {
+            return true
+        }
+        return layout.supportsSplit
+    }
+
     /// Allows empty ranges, may be less than min if max is smaller than min
     private fun Int.coerceInLoosely(min: Int, max: Int) = coerceAtLeast(min).coerceAtMost(max)
 
@@ -491,6 +501,14 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
                     splitLayoutWidth = displayWidth * 3 / 5
                 )
             }
+
+            savedSettings.currentMode == KeyboardMode.Split && !layout.supportsSplit ->
+                RegularKeyboardSize(
+                    width = width,
+                    height = recommendedHeight.roundToInt(),
+                    singleRowHeight = singularRowHeight.roundToInt(),
+                    padding = padding
+                )
 
             savedSettings.currentMode == KeyboardMode.Split ->
                 SplitKeyboardSize(


### PR DESCRIPTION
Add supportsSplit property to Keyboard data class. When false, the Split button is hidden from the mode selector UI and the layout engine falls back to Regular mode if split was previously active. This prevents broken rendering for layouts like ClearFlow whose rows don't split cleanly.