### PR TITLE
Add mirrorInOneHanded support for keyboard layouts

### DIFF
--- a/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/Keyboard.kt
@@ -292,6 +292,13 @@ data class Keyboard(
      */
     val autoShift: Boolean = true,
 
+    /**
+     * (optional) Whether rows should be mirrored (reversed) in one-handed mode. When enabled and
+     * the keyboard is in left-handed one-hand mode, each row's keys are reversed so that keys
+     * like backspace move to the opposite (more reachable) side.
+     */
+    val mirrorInOneHanded: Boolean = false,
+
     val subKeyboards: Map<KeyboardLayoutKind, SubKeyboard> = emptyMap(),
     val imeHint: String? = null
 

--- a/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
@@ -474,7 +474,39 @@ data class LayoutEngine(
             )
         }
 
-        return alignForSplitLayout(computedRowWithWidths)
+        return alignForSplitLayout(mirrorForOneHanded(computedRowWithWidths))
+    }
+
+    private fun mirrorForOneHanded(rows: List<LayoutRow>): List<LayoutRow> {
+        if(!isOneHandedLayout || !keyboard.mirrorInOneHanded) return rows
+
+        val direction = (layoutParams.size as OneHandedKeyboardSize).direction
+        if(direction != OneHandedDirection.Left) return rows
+
+        return rows.map { row ->
+            row.copy(entries = swapOuterKeys(row.entries))
+        }
+    }
+
+    // Swap the leading and trailing non-Regular-width entries (functional keys, gaps, grow keys)
+    // while keeping the inner letter keys in their original order.
+    private fun swapOuterKeys(entries: List<LayoutEntry>): List<LayoutEntry> {
+        fun isOuter(entry: LayoutEntry): Boolean = when(entry) {
+            is LayoutEntry.Gap -> true
+            is LayoutEntry.Key -> entry.data.width != KeyWidth.Regular
+        }
+
+        val leadingCount = entries.indexOfFirst { !isOuter(it) }.let { if(it == -1) entries.size else it }
+        val trailingCount = entries.asReversed().indexOfFirst { !isOuter(it) }.let { if(it == -1) entries.size else it }
+
+        if(leadingCount == 0 && trailingCount == 0) return entries
+        if(leadingCount + trailingCount >= entries.size) return entries
+
+        val leading = entries.subList(0, leadingCount)
+        val middle = entries.subList(leadingCount, entries.size - trailingCount)
+        val trailing = entries.subList(entries.size - trailingCount, entries.size)
+
+        return trailing + middle + leading
     }
 
     private fun mergeDuplicates(row: List<LayoutEntry>): List<LayoutEntry> {


### PR DESCRIPTION
Swap outer functional keys (shift, backspace, action) between left and right sides when the keyboard is in left-handed one-hand mode. Inner letter keys remain in their original order. Layouts opt in via the mirrorInOneHanded YAML property.