### PR TITLE
Add movable and resizable pinned action button (e.g. dictation/mic)

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -395,6 +395,16 @@
     <string name="action_settings_quick_option_language_switch_key">Language switch key</string>
     <string name="action_settings_quick_option_language_switch_key_subtitle">Replace the emoji key with a language switch key. Go to “Edit Actions” to put something else.</string>
     <string name="action_settings_action_settings">Action Settings</string>
+    <string name="action_settings_pinned_position">Pinned action position</string>
+    <string name="action_settings_pinned_position_subtitle">Where pinned actions (e.g. the microphone) appear in the suggestion bar</string>
+    <string name="action_settings_pinned_position_right">Right (default)</string>
+    <string name="action_settings_pinned_position_left">Left of suggestions</string>
+    <string name="action_settings_pinned_position_far_left">Far left (before the actions key)</string>
+    <string name="action_settings_pinned_size">Pinned action button size</string>
+    <string name="action_settings_pinned_size_subtitle">Adjust the size of pinned action buttons in the suggestion bar</string>
+    <string name="action_settings_pinned_size_small">Small</string>
+    <string name="action_settings_pinned_size_normal">Normal</string>
+    <string name="action_settings_pinned_size_large">Large</string>
 
     <!-- Keyboard's size settings -->
     <string name="size_settings_title">Resize Keyboard</string>

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -189,6 +189,18 @@ val OldStyleActionsBar = SettingsKey(
     false
 )
 
+// 0 = right (default), 1 = left of suggestions, 2 = far left (before the actions key)
+val PinnedActionsPosition = SettingsKey(
+    intPreferencesKey("pinnedActionsPosition"),
+    0
+)
+
+// 0 = small, 1 = normal (default), 2 = large
+val PinnedActionsSize = SettingsKey(
+    intPreferencesKey("pinnedActionsSize"),
+    1
+)
+
 
 interface ImportantNotice {
     @Composable fun getText(): String
@@ -566,16 +578,17 @@ fun LazyItemScope.ActionItem(idx: Int, action: Action, onSelect: (Action) -> Uni
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun ActionItemSmall(action: Action, onSelect: (Action) -> Unit, onLongSelect: (Action) -> Unit) {
+fun ActionItemSmall(action: Action, size: Int = 1, onSelect: (Action) -> Unit, onLongSelect: (Action) -> Unit) {
     val bgCol = LocalKeyboardScheme.current.keyboardContainer
     val fgCol = LocalKeyboardScheme.current.onKeyboardContainer
 
-    val circleRadius = with(LocalDensity.current) {
-        16.dp.toPx()
-    }
+    val buttonWidth = when(size) { 0 -> 34.dp; 2 -> 54.dp; else -> 42.dp }
+    val iconSize = when(size) { 0 -> 13.dp; 2 -> 22.dp; else -> 16.dp }
+    val circleRadiusDp = when(size) { 0 -> 13.dp; 2 -> 22.dp; else -> 16.dp }
+    val circleRadius = with(LocalDensity.current) { circleRadiusDp.toPx() }
 
     Box(modifier = Modifier
-        .width(42.dp)
+        .width(buttonWidth)
         .fillMaxHeight()
         .drawBehind {
             drawCircle(
@@ -596,7 +609,7 @@ fun ActionItemSmall(action: Action, onSelect: (Action) -> Unit, onLongSelect: (A
             painter = painterResource(id = action.icon),
             contentDescription = stringResource(action.name),
             tint = fgCol,
-            modifier = Modifier.size(16.dp)
+            modifier = Modifier.size(iconSize)
         )
     }
 }
@@ -788,12 +801,18 @@ fun RowScope.PinnedActionItems(onSelect: (Action) -> Unit, onLongSelect: (Action
         PinnedActions.default
     }
 
+    val size = if(!LocalInspectionMode.current) {
+        useDataStoreValue(PinnedActionsSize)
+    } else {
+        1
+    }
+
     val actionItems = remember(actions) {
         actions.toActionList()
     }
 
     actionItems.forEach {
-        ActionItemSmall(it, onSelect, onLongSelect)
+        ActionItemSmall(it, size, onSelect, onLongSelect)
     }
 }
 
@@ -869,6 +888,19 @@ fun ActionBar(
                 .weight(1.0f), color = actionBarColor()
         ) {
             Row(Modifier.safeKeyboardPadding()) {
+                // 0 = right (default), 1 = left of suggestions, 2 = far left (before the actions key)
+                val pinnedPosition = if(!LocalInspectionMode.current) {
+                    useDataStoreValue(PinnedActionsPosition)
+                } else {
+                    0
+                }
+
+                // Far left: render pinned actions before the actions launcher key
+                if(pinnedPosition == 2 && inlineSuggestions.isEmpty()
+                    && importantNotice == null && !(oldActionBar.value && isActionsExpanded)) {
+                    PinnedActionItems(onActionActivated, onActionAltActivated)
+                }
+
                 ExpandActionsButton(isActionsExpanded) {
                     toggleActionsExpanded()
 
@@ -888,6 +920,10 @@ fun ActionBar(
                     if (importantNotice != null) {
                         ImportantNoticeView(importantNotice)
                     } else {
+                        if(pinnedPosition == 1 && inlineSuggestions.isEmpty()) {
+                            PinnedActionItems(onActionActivated, onActionAltActivated)
+                        }
+
                         if(loading) {
                             Spacer(Modifier.weight(1.0f))
                             CircularProgressIndicator(
@@ -922,7 +958,7 @@ fun ActionBar(
                             Spacer(modifier = Modifier.weight(1.0f))
                         }
 
-                        if(inlineSuggestions.isEmpty()) {
+                        if(pinnedPosition == 0 && inlineSuggestions.isEmpty()) {
                             PinnedActionItems(onActionActivated, onActionAltActivated)
                         }
                     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Actions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Actions.kt
@@ -18,7 +18,11 @@ import org.futo.inputmethod.latin.uix.actions.ensureWellFormed
 import org.futo.inputmethod.latin.uix.actions.toActionEditorItems
 import org.futo.inputmethod.latin.uix.actions.toActionMap
 import org.futo.inputmethod.latin.uix.actions.updateSettingsWithNewActions
+import org.futo.inputmethod.latin.uix.PinnedActionsPosition
+import org.futo.inputmethod.latin.uix.PinnedActionsSize
 import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.inputmethod.latin.uix.setSettingBlocking
+import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
 import org.futo.inputmethod.latin.uix.settings.SettingToggleRaw
@@ -149,6 +153,54 @@ val ActionsScreen = UserSettingsMenu(
         },
 
         // TODO: Add a "Show voice input button" toggle
+
+        UserSetting(
+            name = R.string.action_settings_pinned_position,
+            subtitle = R.string.action_settings_pinned_position_subtitle
+        ) {
+            val context = LocalContext.current
+            val position = useDataStoreValue(PinnedActionsPosition)
+            val labelRight = stringResource(R.string.action_settings_pinned_position_right)
+            val labelLeft = stringResource(R.string.action_settings_pinned_position_left)
+            val labelFarLeft = stringResource(R.string.action_settings_pinned_position_far_left)
+            DropDownPickerSettingItem(
+                label = stringResource(R.string.action_settings_pinned_position),
+                options = listOf(0, 1, 2),
+                selection = position,
+                onSet = { context.setSettingBlocking(PinnedActionsPosition.key, it) },
+                getDisplayName = { v ->
+                    when(v) {
+                        1 -> labelLeft
+                        2 -> labelFarLeft
+                        else -> labelRight
+                    }
+                }
+            )
+        },
+
+        UserSetting(
+            name = R.string.action_settings_pinned_size,
+            subtitle = R.string.action_settings_pinned_size_subtitle
+        ) {
+            val context = LocalContext.current
+            val size = useDataStoreValue(PinnedActionsSize)
+            val labelSmall = stringResource(R.string.action_settings_pinned_size_small)
+            val labelNormal = stringResource(R.string.action_settings_pinned_size_normal)
+            val labelLarge = stringResource(R.string.action_settings_pinned_size_large)
+            DropDownPickerSettingItem(
+                label = stringResource(R.string.action_settings_pinned_size),
+                options = listOf(0, 1, 2),
+                selection = size,
+                onSet = { context.setSettingBlocking(PinnedActionsSize.key, it) },
+                getDisplayName = { v ->
+                    when(v) {
+                        0 -> labelSmall
+                        2 -> labelLarge
+                        else -> labelNormal
+                    }
+                }
+            )
+        },
 
         userSettingNavigationItem(
             title = R.string.action_editor_title,


### PR DESCRIPTION
## Summary

Pinned action buttons (e.g. the mic/dictation button) are fixed to the right side of the suggestion bar at a single small size, which is hard to use on tablets and on in-car / TV screens.

This PR adds two settings under **Settings → Actions**, applying to whatever action(s) are pinned via Edit Actions (not just the mic):

- **Pinned action position** — Right (default) / Left of suggestions / Far left (before the actions key)
- **Pinned action button size** — Small / Normal (default) / Large

## Changes

- `ActionBar.kt`: add `PinnedActionsPosition` (int: 0 = right, 1 = left of suggestions, 2 = far left) and `PinnedActionsSize` (int 0/1/2) `SettingsKey`s; `ActionItemSmall` takes a `size` that scales button width and icon; `PinnedActionItems` reads the size; the `ActionBar` row renders the pinned items right of the suggestions, left of the suggestions, or before the actions launcher key depending on the position setting.
- `Actions.kt`: expose both settings in the Settings → Actions quick options as dropdowns.
- `strings-uix.xml`: string resources for the labels and options.

## Motivation

Tablet, in-car, and TV use, where the default right-side small mic button is difficult to reach. Moving it left — optionally all the way before the actions key — and enlarging it significantly improves reachability. Verified on a 768×1024 head unit: the position dropdown moves the pinned mic right / left-of-suggestions / before the actions key as selected.
