### PR TITLE
Add Clipboard History Search Feature

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -69,6 +69,7 @@
     <!-- Must be fairly short -->
     <string name="action_clipboard_manager_clear_unpinned_items_button">Clear</string>
     <string name="action_clipboard_manager_clear_clipboard">Clear clipboard</string>
+    <string name="action_clipboard_manager_search">Search clipboard&#8230;</string>
     <string name="action_clipboard_manager_error_device_locked_title">Device Locked</string>
     <string name="action_clipboard_manager_error_device_locked_text">Please unlock your device to access clipboard history</string>
     <string name="action_clipboard_manager_error_general_title">Clipboard Error</string>

--- a/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
@@ -344,3 +344,52 @@ fun SettingsTextEdit(
         }
     }
 }
+
+@Composable
+fun ActionSearchEditText(
+    text: MutableState<String>,
+    placeholder: String? = null,
+    icon: (@Composable () -> Unit)? = null,
+    trailingIcon: (@Composable () -> Unit)? = null,
+    autocorrect: Boolean = false,
+    autofocus: Boolean = false
+) {
+    val manager = if(!LocalInspectionMode.current) LocalManager.current else null
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp, 0.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            icon?.let {
+                it.invoke()
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+
+            GenericEditTextCompose(
+                text = text,
+                multiline = false,
+                textSize = 16.sp,
+                placeholder = placeholder,
+                autocorrect = autocorrect,
+                autofocus = autofocus,
+                modifier = Modifier.weight(1.0f),
+                onOverride = { ic, ed ->
+                    manager!!.overrideInputConnection(ic, ed)
+                },
+                onUnoverride = {
+                    manager!!.unsetInputConnection()
+                }
+            )
+
+            trailingIcon?.let {
+                Spacer(modifier = Modifier.width(8.dp))
+                it.invoke()
+            }
+        }
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
@@ -27,12 +27,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
@@ -64,6 +67,7 @@ import kotlinx.serialization.json.Json
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.uix.Action
+import org.futo.inputmethod.latin.uix.ActionSearchEditText
 import org.futo.inputmethod.latin.uix.ActionWindow
 import org.futo.inputmethod.latin.uix.DialogRequestItem
 import org.futo.inputmethod.latin.uix.PersistentActionState
@@ -781,14 +785,45 @@ val ClipboardHistoryAction = Action(
                         }
                     }
                 } else {
-                    val sortedList = when {
-                        useDataStoreValue(ClipboardShowPinnedOnTop) -> clipboardHistoryManager.clipboardHistory
-                            .sortedBy { it.pinned }
+                    val searchQueryState = remember { mutableStateOf("") }
+                    val searchQuery = searchQueryState.value
+                    
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        ActionSearchEditText(
+                            text = searchQueryState,
+                            placeholder = stringResource(R.string.action_clipboard_manager_search),
+                            icon = { 
+                                Icon(
+                                    painter = painterResource(id = R.drawable.sym_keyboard_search_lxx_light),
+                                    contentDescription = stringResource(R.string.action_clipboard_manager_search),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                ) 
+                            },
+                            trailingIcon = {
+                                if (searchQuery.isNotEmpty()) {
+                                    androidx.compose.material3.IconButton(onClick = { searchQueryState.value = "" }) {
+                                        Icon(
+                                            painterResource(id = R.drawable.close),
+                                            contentDescription = stringResource(R.string.action_clipboard_manager_remove_item)
+                                        )
+                                    }
+                                }
+                            }
+                        )
+                        Spacer(modifier = Modifier.padding(bottom = 6.dp))
 
-                        else -> clipboardHistoryManager.clipboardHistory
-                    }
+                        val filteredList = clipboardHistoryManager.clipboardHistory.filter { 
+                            searchQuery.isBlank() || 
+                            it.text?.contains(searchQuery, ignoreCase = true) == true ||
+                            it.mimeTypes.any { mime -> mime.contains(searchQuery, ignoreCase = true) }
+                        }
 
-                    val useSingleColumn = useDataStoreValue(ClipboardSingleColumn)
+                        val sortedList = when {
+                            useDataStoreValue(ClipboardShowPinnedOnTop) -> filteredList.sortedBy { it.pinned }
+                            else -> filteredList
+                        }
+
+                        val useSingleColumn = useDataStoreValue(ClipboardSingleColumn)
                     val columns = if(useSingleColumn) {
                         StaggeredGridCells.Fixed(1)
                     } else {
@@ -851,6 +886,7 @@ val ClipboardHistoryAction = Action(
                                 })
                         }
                     }
+                    } // Column
                 }
             }
         }


### PR DESCRIPTION
PR for  #1908 and #659, #1478

This PR implements a robust case-insensitive search feature within the Clipboard Manager.

### Changes:
- Added an \`ActionSearchEditText\` to correctly map IME inputs within the \`ClipboardHistoryAction\` window.
- Integrated search query text filtering across clipboard item contents and MIME types.
- Updated UI strings and layout to match FUTO keyboard standards.
