### PR TITLE
Add configurable flick gesture sensitivity setting

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -478,6 +478,10 @@
     <string name="keyboard_settings_period_key">Quick period key</string>
     <string name="keyboard_settings_period_key_subtitle2">Replaces the layout of long-pressed period key with a flickable layout: ! , . ?</string>
 
+    <string name="keyboard_settings_flick_threshold">Flick sensitivity</string>
+    <string name="keyboard_settings_flick_threshold_subtitle">Adjust how far you need to swipe to trigger a flick action. Lower values make flick easier to trigger.</string>
+    <string name="keyboard_settings_flick_threshold_default">Default (33%)</string>
+
     <string name="keyboard_settings_number_row_title">Number row</string>
     <string name="keyboard_settings_number_row_style">Number row style</string>
     <!-- Slightly more compact than a full key, has no background -->

--- a/java/src/org/futo/inputmethod/keyboard/Key.kt
+++ b/java/src/org/futo/inputmethod/keyboard/Key.kt
@@ -567,6 +567,7 @@ data class Key(
         get() = mFlickDirection
 
     companion object {
+        @Volatile
         @JvmStatic
         var flickThresholdRatio: Float = 1.0f / 3.0f
 

--- a/java/src/org/futo/inputmethod/keyboard/Key.kt
+++ b/java/src/org/futo/inputmethod/keyboard/Key.kt
@@ -552,7 +552,7 @@ data class Key(
             val dirs = computeDirectionsFromDeltaPos(
                 dx = dx.toDouble(),
                 dy = dy.toDouble(),
-                threshold = (width / 3).toDouble()
+                threshold = (width * flickThresholdRatio).toDouble()
             )
             dirs.firstOrNull { flickKeys.contains(it) }
         }
@@ -567,6 +567,9 @@ data class Key(
         get() = mFlickDirection
 
     companion object {
+        @JvmStatic
+        var flickThresholdRatio: Float = 1.0f / 3.0f
+
         @JvmStatic
         fun removeRedundantMoreKeys(
             key: Key,

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.futo.inputmethod.accessibility.AccessibilityUtils
+import org.futo.inputmethod.keyboard.Key
 import org.futo.inputmethod.engine.ExpandableSuggestionBarConfiguration
 import org.futo.inputmethod.engine.IMEManager
 import org.futo.inputmethod.engine.general.WordLearner
@@ -62,6 +63,8 @@ import org.futo.inputmethod.latin.SuggestedWords.SuggestedWordInfo
 import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.settings.Settings
 import org.futo.inputmethod.latin.uix.BasicThemeProvider
+import org.futo.inputmethod.latin.uix.settings.pages.FLICK_THRESHOLD_DEFAULT
+import org.futo.inputmethod.latin.uix.settings.pages.flickThresholdSetting
 import org.futo.inputmethod.latin.uix.DataStoreHelper
 import org.futo.inputmethod.latin.uix.DynamicThemeProvider
 import org.futo.inputmethod.latin.uix.DynamicThemeProviderOwner
@@ -422,6 +425,15 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
                         }
                     }
                 }
+        }
+
+        Key.flickThresholdRatio = getSettingBlocking(flickThresholdSetting).let {
+            if(it < 0.0f) FLICK_THRESHOLD_DEFAULT else it
+        }
+        launchJob {
+            getSettingFlow(flickThresholdSetting).collect {
+                Key.flickThresholdRatio = if(it < 0.0f) FLICK_THRESHOLD_DEFAULT else it
+            }
         }
 
         launchJob {

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -142,6 +142,13 @@ val keySoundVolumeSetting = SettingsKey(
     0.0f
 )
 
+val flickThresholdSetting = SettingsKey(
+    floatPreferencesKey("flick_threshold_ratio"),
+    -1.0f
+)
+
+const val FLICK_THRESHOLD_DEFAULT = 1.0f / 3.0f
+
 val ActionBarDisplayedSetting = SettingsKey(
     booleanPreferencesKey("enable_action_bar"),
     true
@@ -793,6 +800,28 @@ val KeyboardSettingsMenu = UserSettingsMenu(
             subtitle = R.string.keyboard_settings_period_key_subtitle2,
             key = Settings.PREF_ENABLE_ALT_PERIOD_KEY,
             default = {false},
+        ),
+        UserSetting(
+            name = R.string.keyboard_settings_flick_threshold,
+            subtitle = R.string.keyboard_settings_flick_threshold_subtitle,
+            component = {
+                val context = LocalContext.current
+                SettingSlider(
+                    title = stringResource(R.string.keyboard_settings_flick_threshold),
+                    setting = flickThresholdSetting,
+                    range = -1.0f .. 0.8f,
+                    hardRange = -1.0f .. 1.0f,
+                    transform = { if(it <= 0.0f) -1.0f else it },
+                    indicator = {
+                        if(it < 0.0f) {
+                            context.getString(R.string.keyboard_settings_flick_threshold_default)
+                        } else {
+                            "${(it * 100).roundToInt()}%"
+                        }
+                    },
+                    subtitle = stringResource(R.string.keyboard_settings_flick_threshold_subtitle)
+                )
+            }
         ),
     )
 )

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -809,9 +809,9 @@ val KeyboardSettingsMenu = UserSettingsMenu(
                 SettingSlider(
                     title = stringResource(R.string.keyboard_settings_flick_threshold),
                     setting = flickThresholdSetting,
-                    range = -1.0f .. 0.8f,
-                    hardRange = -1.0f .. 1.0f,
-                    transform = { if(it <= 0.0f) -1.0f else it },
+                    range = -1.0f .. 80.0f,
+                    hardRange = -1.0f .. 100.0f,
+                    transform = { if(it <= 0.0f) -1.0f else it / 100.0f },
                     indicator = {
                         if(it < 0.0f) {
                             context.getString(R.string.keyboard_settings_flick_threshold_default)


### PR DESCRIPTION
## Summary
This PR adds a new user-configurable setting to adjust the sensitivity of flick gestures on the keyboard. Users can now customize how far they need to swipe to trigger a flick action, with a default value of 33%.

## Key Changes
- **New Settings Key**: Added `flickThresholdSetting` to store the flick threshold ratio with a default value of -1.0f (which maps to the default 1/3 threshold)
- **UI Setting**: Added a new slider control in the Keyboard Settings menu under "Flick sensitivity" that allows users to adjust the threshold from 0-80% (with a hard range up to 100%)
- **Core Implementation**: Modified `Key.kt` to use the configurable `flickThresholdRatio` instead of the hardcoded `width / 3` calculation
- **Settings Integration**: Updated `LatinIME.kt` to read the flick threshold setting on initialization and observe changes in real-time
- **Localization**: Added English strings for the new setting, including the title, subtitle, and default value indicator

## Notable Implementation Details
- The threshold value uses -1.0f as a sentinel to indicate "use default" (1/3), allowing users to reset to default behavior
- The slider transforms the UI range (0-80%) to the actual threshold ratio (0.0-0.8), with negative values mapping back to the default
- The `flickThresholdRatio` is stored as a volatile static variable in the `Key` companion object for thread-safe access across the application
- Settings changes are observed asynchronously and applied immediately without requiring a restart