### PR TITLE
Fix voice input text duplication in terminal apps (Haven, Termux)

### DIFF
--- a/java/src/org/futo/inputmethod/engine/general/ActionInputTransactionIME.kt
+++ b/java/src/org/futo/inputmethod/engine/general/ActionInputTransactionIME.kt
@@ -15,7 +15,9 @@ import org.futo.inputmethod.latin.uix.utils.TextContext
 import org.futo.inputmethod.v2keyboard.KeyboardLayoutSetV2
 
 class ActionInputTransactionIME(val helper: IMEHelper) : IMEInterface, ActionInputTransaction {
-    val ic = if(helper.context.getSetting(VoiceInputAlternativeIC) && SupportsNonComposing) {
+    val ic = if(helper.context.getSetting(VoiceInputAlternativeIC)
+                && SupportsNonComposing
+                && helper.getCurrentEditorInfo()?.inputType != 0) {
         InputConnectionInternalComposingWrapper(
             helper.context.getSetting(VoiceInputAlternativeICComposing),
             true,

--- a/java/src/org/futo/inputmethod/latin/InputAttributes.java
+++ b/java/src/org/futo/inputmethod/latin/InputAttributes.java
@@ -385,6 +385,9 @@ public final class InputAttributes {
         if(editorInfo.packageName.startsWith("com.termux") && editorInfo.inputType == 0)
             return CODE_FIELD_NO_COMPOSITION;
 
+        if(editorInfo.packageName.startsWith("sh.haven.app") && editorInfo.inputType == 0)
+            return CODE_FIELD_NO_COMPOSITION;
+
         if(editorInfo.packageName.startsWith("com.android.virtualization.terminal") && noSuggestions)
             return CODE_FIELD_NO_COMPOSITION;
 


### PR DESCRIPTION
## Problem

When using voice input in terminal applications, dictated text is duplicated. The user speaks a phrase and it appears correctly, but then appears again with minor changes (punctuation adjustments, word corrections) appended instead of replacing the original.

Reproduced in [Haven](https://github.com/havenweb/haven) (`sh.haven.app`) and expected to affect any terminal-style app including Termux.

## Root Cause

Voice input uses `InputConnectionInternalComposingWrapper`, which implements partial result updates via a delete-then-retype strategy:

1. As speech recognition produces interim results, it calls `setComposingText()` on the wrapper
2. The wrapper translates this into `deleteSurroundingText()` (to remove the previous partial) followed by `commitText()` (to write the revised version)
3. These are batched and flushed together via `InputConnectionWithBufferingWrapper`

In a terminal app, `deleteSurroundingText()` is silently ignored — terminals don't support standard Android `InputConnection` cursor/deletion APIs. The delete no-ops, and the revised text is appended on top of the original, producing duplicate output.

## Fix

`InputAttributes.java` already detects terminal apps (checking `inputType == 0`) and sets `CODE_FIELD_NO_COMPOSITION` for the regular IME path. However, `ActionInputTransactionIME` — which handles voice input — constructs its own `InputConnectionInternalComposingWrapper` unconditionally, bypassing this detection entirely.

This fix adds a check in `ActionInputTransactionIME` to skip the composing wrapper when `inputType == 0`. In that case the raw `InputConnection` is used instead, so only the final committed result is sent to the app — no partial deletes or rewrites.

`InputAttributes.java` is also updated to register `sh.haven.app` alongside the existing Termux entry, covering the regular IME path for Haven.

## Changes

**`ActionInputTransactionIME.kt`**
```kotlin
// Before
val ic = if(helper.context.getSetting(VoiceInputAlternativeIC) && SupportsNonComposing) {

// After
val ic = if(helper.context.getSetting(VoiceInputAlternativeIC)
            && SupportsNonComposing
            && helper.getCurrentEditorInfo()?.inputType != 0) {
```

**`InputAttributes.java`**
```java
// Added alongside the existing Termux entry:
if(editorInfo.packageName.startsWith("sh.haven.app") && editorInfo.inputType == 0)
    return CODE_FIELD_NO_COMPOSITION;
```

## Testing

Built and installed the `unstableDebug` variant. Voice input in Haven no longer produces duplicate text. Regular voice input in standard text fields is unaffected.

## Related Issues

- #1047
- #923

## Notes

- The `inputType == 0` check mirrors the condition already used in `InputAttributes.java` for Termux — this is not a new heuristic, just applying the existing one to the voice input path.
- A broader improvement could buffer all partial results in memory and only commit the final result to terminal apps, but that is a larger change and out of scope for this fix.