### PR TITLE
feat: Allow autocorrect in address bars

### DIFF
--- a/java/res/values/strings.xml
+++ b/java/res/values/strings.xml
@@ -72,6 +72,11 @@
     <!-- Search tags for the setting -->
     <string name="auto_correction_tags">autocorrect</string>
 
+    <!-- Option to enable autocorrect in address bar inputs -->
+    <string name="auto_correct_address_bars">Auto-correct in address bars</string>
+    <!-- Description for "auto_correct_address_bars" -->
+    <string name="auto_correct_address_bars_summary">Auto-correction will apply when typing in address bars (URL, email address inputs)</string>
+
     <!-- Option to enable using next word suggestions. After the user types a space, with this option on, the keyboard will try to predict the next word. -->
     <string name="bigram_prediction">Next-word suggestions</string>
     <!-- Description for "next word suggestion" option. This displays suggestions even when there is no input, based on the previous word. -->

--- a/java/src/org/futo/inputmethod/latin/InputAttributes.java
+++ b/java/src/org/futo/inputmethod/latin/InputAttributes.java
@@ -27,6 +27,7 @@ import android.view.inputmethod.EditorInfo;
 import androidx.annotation.Nullable;
 
 import org.futo.inputmethod.latin.common.StringUtils;
+import org.futo.inputmethod.latin.settings.Settings;
 import org.futo.inputmethod.latin.utils.InputTypeUtils;
 
 import java.util.ArrayList;
@@ -130,6 +131,9 @@ public final class InputAttributes {
         final boolean forceNoSuggestionsByPrivateFlag = editorInfo.privateImeOptions != null
                 && editorInfo.privateImeOptions.contains("org.futo.inputmethod.latin.NoSuggestions=1");
 
+        final Settings settings = Settings.getInstance();
+        final boolean forceAutocorrectInAddressBars = settings.getCurrent().isAutoCorrectAddressBarsEnabled();
+
         // TODO: Have a helper method in InputTypeUtils
         // Make sure that passwords are not displayed in {@link SuggestionStripView}.
         final boolean shouldSuppressSuggestions = mIsPasswordField
@@ -148,8 +152,8 @@ public final class InputAttributes {
         // TODO: This may need adjustment
         mInputTypeNoAutoCorrect = shouldSuppressSuggestions
                 //|| (variation == InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT && !flagAutoCorrect)
-                || InputTypeUtils.isEmailVariation(variation)
-                || InputType.TYPE_TEXT_VARIATION_URI == variation
+                || (InputTypeUtils.isEmailVariation(variation) && !forceAutocorrectInAddressBars)
+                || (InputType.TYPE_TEXT_VARIATION_URI == variation && !forceAutocorrectInAddressBars)
                 || InputType.TYPE_TEXT_VARIATION_FILTER == variation
                 || (flagNoSuggestions && !flagAutoCorrect && variation != InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT)
                 || mIsCodeField;
@@ -171,12 +175,12 @@ public final class InputAttributes {
         mApplicationSpecifiedCompletionOn = flagAutoComplete && isFullscreenMode;
 
         // If we come here, inputClass is always TYPE_CLASS_TEXT
-        mIsGeneralTextInput = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS != variation
+        mIsGeneralTextInput = (InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS != variation || forceAutocorrectInAddressBars)
                 && InputType.TYPE_TEXT_VARIATION_PASSWORD != variation
                 && InputType.TYPE_TEXT_VARIATION_PHONETIC != variation
-                && InputType.TYPE_TEXT_VARIATION_URI != variation
+                && (InputType.TYPE_TEXT_VARIATION_URI != variation || forceAutocorrectInAddressBars)
                 && InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD != variation
-                && InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS != variation
+                && (InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS != variation || forceAutocorrectInAddressBars)
                 && InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD != variation;
 
         boolean noLearning = false;

--- a/java/src/org/futo/inputmethod/latin/settings/Settings.java
+++ b/java/src/org/futo/inputmethod/latin/settings/Settings.java
@@ -62,6 +62,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_AUTO_CORRECTION_THRESHOLD_OBSOLETE =
             "auto_correction_threshold";
     public static final String PREF_AUTO_CORRECTION = "pref_key_auto_correction";
+    public static final String PREF_AUTO_CORRECT_ADDRESS_BARS = "auto_correct_address_bars";
     // PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE is obsolete. Use PREF_SHOW_SUGGESTIONS instead.
     public static final String PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE = "show_suggestions_setting";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";

--- a/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
@@ -120,6 +120,7 @@ public class SettingsValues {
     public final float mPlausibilityThreshold;
     public final boolean mAutoCorrectionEnabledPerUserSettings;
     public final boolean mAutoCorrectionEnabledPerTextFieldSettings;
+    private final boolean mAutoCorrectAddressBarsEnabled;
     private final boolean mSuggestionsEnabledPerUserSettings;
     private final AsyncResultHolder<AppWorkaroundsUtils> mAppWorkarounds;
 
@@ -226,6 +227,7 @@ public class SettingsValues {
         mAutoCorrectionEnabledPerUserSettings = mAutoCorrectEnabled
                 && !mInputAttributes.mInputTypeNoAutoCorrect;
         mAutoCorrectionEnabledPerTextFieldSettings = !mInputAttributes.mInputTypeNoAutoCorrect;
+        mAutoCorrectAddressBarsEnabled = readAutoCorrectAddressBarsEnabled(prefs);
         mSuggestionsEnabledPerUserSettings = readSuggestionsEnabled(prefs);
         mIsInternal = Settings.isInternal(prefs);
         mHasCustomKeyPreviewAnimationParams = prefs.getBoolean(
@@ -277,6 +279,10 @@ public class SettingsValues {
     public boolean needsToLookupSuggestions() {
         return mInputAttributes.mShouldShowSuggestions
                 && (mAutoCorrectionEnabledPerUserSettings || isSuggestionsEnabledPerUserSettings());
+    }
+
+    public boolean isAutoCorrectAddressBarsEnabled() {
+        return mAutoCorrectAddressBarsEnabled;
     }
 
     public boolean isSuggestionsEnabledPerUserSettings() {
@@ -362,6 +368,10 @@ public class SettingsValues {
     }
 
     private static final String SUGGESTIONS_VISIBILITY_HIDE_VALUE_OBSOLETE = "2";
+
+    private static boolean readAutoCorrectAddressBarsEnabled(final SharedPreferences prefs) {
+        return prefs.getBoolean(Settings.PREF_AUTO_CORRECT_ADDRESS_BARS, false);
+    }
 
     private static boolean readSuggestionsEnabled(final SharedPreferences prefs) {
         if (prefs.contains(Settings.PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE)) {

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/PredictiveText.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/PredictiveText.kt
@@ -87,6 +87,13 @@ val PredictiveTextMenu = UserSettingsMenu(
         ).copy(searchTags = R.string.auto_correction_tags),
 
         userSettingToggleSharedPrefs(
+            title = R.string.auto_correct_address_bars,
+            subtitle = R.string.auto_correct_address_bars_summary,
+            key = Settings.PREF_AUTO_CORRECT_ADDRESS_BARS,
+            default = {false}
+        ),
+
+        userSettingToggleSharedPrefs(
             title = R.string.prediction_settings_smart_keyhit_detection,
             subtitle = R.string.prediction_settings_smart_keyhit_detection_subtitle,
             key = Settings.PREF_USE_DICT_KEY_BOOSTING,
@@ -97,6 +104,13 @@ val PredictiveTextMenu = UserSettingsMenu(
             title = R.string.prefs_show_suggestions,
             subtitle = R.string.prefs_show_suggestions_summary,
             key = Settings.PREF_SHOW_SUGGESTIONS,
+            default = {true}
+        ),
+
+        userSettingToggleSharedPrefs(
+            title = R.string.use_personalized_dicts,
+            subtitle = R.string.use_personalized_dicts_summary,
+            key = Settings.PREF_KEY_USE_PERSONALIZED_DICTS,
             default = {true}
         ),
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/PredictiveText.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/PredictiveText.kt
@@ -114,13 +114,6 @@ val PredictiveTextMenu = UserSettingsMenu(
             default = {true}
         ),
 
-        userSettingToggleSharedPrefs(
-            title = R.string.use_personalized_dicts,
-            subtitle = R.string.use_personalized_dicts_summary,
-            key = Settings.PREF_KEY_USE_PERSONALIZED_DICTS,
-            default = {true}
-        ),
-
         //if(!transformerLmEnabled) {
         userSettingToggleSharedPrefs(
             title = R.string.bigram_prediction,


### PR DESCRIPTION
This pull request adds a new optional toggle to allow autocorrect to work in address bars (web browser URL and email address fields). This is disabled by default.

This is a feature in some keyboards such as SwiftKey. I find it useful for when I am trying to make a search in a web browser's URL field. Not sure if it is particularly useful for email address fields, but I also made it autocorrect for those fields too. Maybe that can be removed if some people find it to be unsuitable.

Closes #1614