### PR TITLE
Added the ability to Undo a previously autocorrected word

### DIFF
--- a/java/src/org/futo/inputmethod/latin/Suggest.java
+++ b/java/src/org/futo/inputmethod/latin/Suggest.java
@@ -19,6 +19,7 @@ package org.futo.inputmethod.latin;
 import android.text.TextUtils;
 import android.util.Log;
 
+import static org.futo.inputmethod.latin.SuggestedWords.SuggestedWordInfo.KIND_CORRECTION;
 import static org.futo.inputmethod.latin.define.DecoderSpecificConstants.SHOULD_AUTO_CORRECT_USING_NON_WHITE_LISTED_SUGGESTION;
 import static org.futo.inputmethod.latin.define.DecoderSpecificConstants.SHOULD_REMOVE_PREVIOUSLY_REJECTED_SUGGESTION;
 
@@ -32,6 +33,7 @@ import org.futo.inputmethod.latin.utils.AutoCorrectionUtils;
 import org.futo.inputmethod.latin.utils.BinaryDictionaryUtils;
 import org.futo.inputmethod.latin.utils.SuggestionResults;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -165,15 +167,27 @@ public final class Suggest {
             final float autoCorrectionThreshold, final boolean numberRowActive
     ) {
         final String typedWordString = wordComposer.getTypedWord();
+        final String revertWord = wordComposer.getRevertWord();
         final int trailingSingleQuotesCount =
                 StringUtils.getTrailingSingleQuotesCount(typedWordString);
         final String consideredWord = trailingSingleQuotesCount > 0
                 ? typedWordString.substring(0, typedWordString.length() - trailingSingleQuotesCount)
                 : typedWordString;
 
-        final ArrayList<SuggestedWordInfo> suggestionsContainer =
-                getTransformedSuggestedWordInfoList(wordComposer, suggestionResults,
-                        trailingSingleQuotesCount, locale);
+        ArrayList<SuggestedWordInfo> suggestionsContainer = getTransformedSuggestedWordInfoList(wordComposer, suggestionResults, trailingSingleQuotesCount, locale);;
+        if (revertWord != null) {
+            SuggestedWordInfo revertSuggestion = new SuggestedWordInfo(
+                    revertWord, "", 100, KIND_CORRECTION, null, -1, -1);
+            // Puts the revertWord in the left most slot, which is the 2nd element in the Array
+            if(!suggestionsContainer.isEmpty()){
+                SuggestedWordInfo originalSuggestion = suggestionsContainer.get(1);
+                suggestionsContainer.set(1, revertSuggestion);
+                suggestionsContainer.set(0, originalSuggestion);
+            } else {
+                suggestionsContainer.add(revertSuggestion);
+            }
+        }
+
 
         boolean foundInDictionary = false;
         Dictionary sourceDictionaryOfRemovedWord = null;

--- a/java/src/org/futo/inputmethod/latin/WordComposer.java
+++ b/java/src/org/futo/inputmethod/latin/WordComposer.java
@@ -83,6 +83,8 @@ public final class WordComposer {
     // code points.
     private int mCodePointSize;
     private int mCursorPositionWithinWord;
+    // is set, when the word has been autocorrected before in this session
+    private String mRevertWord;
 
     /**
      * Whether the composing word has the only first char capitalized.
@@ -103,6 +105,13 @@ public final class WordComposer {
 
     public ComposedData getComposedDataSnapshot() {
         return new ComposedData(getInputPointers(), isBatchMode(), mTypedWordCache.toString());
+    }
+
+    public void setRevertWord(String word){
+        mRevertWord = word;
+    }
+    public String getRevertWord(){
+        return mRevertWord;
     }
 
     /**
@@ -137,6 +146,7 @@ public final class WordComposer {
         mIsBatchMode = false;
         mCursorPositionWithinWord = 0;
         mIsAttachedToNonWord = false;
+        mRevertWord = null;
 
         if(alsoResetRejectedBatchSuggestion) mRejectedBatchModeSuggestion = null;
         refreshTypedWordCache();

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -371,10 +371,13 @@ public final class InputLogic {
         // for the sequence of language switching.
         inputTransaction.setDidAffectContents();
 
-        if(suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_UNDO) {
+        if(suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_UNDO || suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_CORRECTION) {
             inputTransaction.setRequiresUpdateSuggestions();
 
-            mConnection.finishComposingText();
+            if (suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_UNDO){
+                mConnection.finishComposingText();
+            }
+
             mWordComposer.reset(true);
 
             mConnection.commitText(suggestionInfo.mWord, 1);

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -62,6 +62,7 @@ import org.futo.inputmethod.latin.utils.TextRange;
 import java.text.BreakIterator;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
@@ -118,6 +119,8 @@ public final class InputLogic {
     // Note: This does not have a composing span, so it must be handled separately.
     private String mWordBeingCorrectedByCursor = null;
 
+    private HashMap<String, String> mAutocorrectedWords = new HashMap<>();
+
     /**
      * Create a new instance of the input logic.
      * @param imeHelper the interface to access IME stuff
@@ -168,6 +171,7 @@ public final class InputLogic {
         mRecapitalizeStatus.disable(); // Do not perform recapitalize until the cursor is moved once
         mCurrentlyPressedHardwareKeys.clear();
         mSuggestedWords = SuggestedWords.getEmptyInstance();
+        mAutocorrectedWords.clear();
         mLastEvents.clear();
 
         final EditorInfo ei = getCurrentInputEditorInfo();
@@ -2025,6 +2029,11 @@ public final class InputLogic {
         mConnection.setComposingRegion(expectedCursorPosition - numberOfCharsInWordBeforeCursor,
                 expectedCursorPosition + range.getNumberOfCharsInWordAfterCursor(), typedWordString);
 
+        if (mAutocorrectedWords.containsKey(typedWordString)){
+            mWordComposer.setRevertWord(mAutocorrectedWords.get(typedWordString));
+            Log.d(TAG, "autocorrected word found in hashmap:"+typedWordString+"->"+mAutocorrectedWords.get(typedWordString));
+        };
+
         mConnection.send();
         return true;
     }
@@ -2654,6 +2663,13 @@ public final class InputLogic {
         final SuggestedWords suggestedWords = mSuggestedWords;
         // TODO: Locale should be determined based on context and the text given.
         final Locale locale = getDictionaryFacilitatorLocale();
+
+        final String originalWord = mWordComposer.getTypedWord();
+
+        if(!originalWord.equals(chosenWord) && !TextUtils.isEmpty(originalWord)) {
+            mAutocorrectedWords.put(chosenWord, originalWord);
+        }
+
         final CharSequence chosenWordWithSuggestions = chosenWord;
         // b/21926256
         //      SuggestionSpanUtils.getTextWithSuggestionSpan(mLatinIME, chosenWord,

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -18,6 +18,7 @@ package org.futo.inputmethod.latin.inputlogic;
 
 import android.os.SystemClock;
 import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.SuggestionSpan;
 import android.util.Log;
@@ -371,18 +372,37 @@ public final class InputLogic {
         // for the sequence of language switching.
         inputTransaction.setDidAffectContents();
 
-        if(suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_UNDO || suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_CORRECTION) {
-            inputTransaction.setRequiresUpdateSuggestions();
+        switch (suggestionInfo.mKindAndFlags){
+            case SuggestedWordInfo.KIND_UNDO: {
+                inputTransaction.setRequiresUpdateSuggestions();
 
-            if (suggestionInfo.mKindAndFlags == SuggestedWordInfo.KIND_UNDO){
                 mConnection.finishComposingText();
+
+                mWordComposer.reset(true);
+
+                mConnection.commitText(suggestionInfo.mWord, 1);
+
+                return inputTransaction;
             }
+            case SuggestedWordInfo.KIND_CORRECTION:{
+                inputTransaction.setRequiresUpdateSuggestions();
 
-            mWordComposer.reset(true);
+                mWordComposer.reset(true);
 
-            mConnection.commitText(suggestionInfo.mWord, 1);
+                final NgramContext ngramContext = mConnection.getNgramContextFromNthPreviousWord(
+                        settingsValues.mSpacingAndPunctuations, 1);
+                performAdditionToUserHistoryDictionary(settingsValues, suggestionInfo.mWord, ngramContext, 1);
 
-            return inputTransaction;
+                SpannableStringBuilder correctedWord = new SpannableStringBuilder(suggestionInfo.mWord);
+
+                // add space and remove leading space to set new cursor position after the space and avoid double spacing
+                mConnection.commitText(correctedWord.append(" "), 1);
+                if (mConnection.spaceFollowsCursor()) {
+                    mConnection.removeLeadingSpace();
+                }
+
+                return inputTransaction;
+            }
         }
 
         mConnection.beginBatchEdit();


### PR DESCRIPTION
Currently, this ability only exists when undoing the last word typed word. 

This pull request makes it possible to undo any word as long as you don't close the keyboard. This puts the word into the left most suggestion slot as seen in the following image. "Tezt" is the original text that I wrote before autocorrection edited the word.

<img width="376" height="823" alt="image" src="https://github.com/user-attachments/assets/a51ea79e-b122-4cd8-a8e7-b049110b73c5" />

This implementation isn't as good as Gboard's, because Gboard tracks which word exactly was changed. I also tried that approach, but Futo Keyboard currently strips all SpannedString metadata when writing into the TextView. That's why I used a simpler HashMap approach to archive a similar result


