### PR TITLE
Fix in-app LM docs link (fixes #2040)

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/modelmanager/ModelList.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/modelmanager/ModelList.kt
@@ -94,7 +94,7 @@ fun ModelListScreen(navController: NavHostController = rememberNavController()) 
             title = "Docs",
             style = NavigationItemStyle.Misc,
             navigate = {
-                context.openURI("https://gitlab.futo.org/alex/keyboard-wiki/-/wikis/Keyboard-LM-docs")
+                context.openURI("https://gitlab.futo.org/alex/futo-keyboard-lm-docs/-/blob/main/README.md")
             }
         )
         NavigationItem(


### PR DESCRIPTION
## Summary

- Update the Transformer Models `Docs` action to point at the current public LM docs README.
- Replace the old GitLab wiki URL that now returns 404.

## Verification

- `curl -L -s -o /dev/null -w "%{http_code}" https://gitlab.futo.org/alex/keyboard-wiki/-/wikis/Keyboard-LM-docs` -> `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://gitlab.futo.org/alex/futo-keyboard-lm-docs/-/blob/main/README.md` -> `200`

Fixes #2040