### PR TITLE
fix(inputlogic): start double-space timer on swallowed space

### DIFF
--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -968,6 +968,7 @@ public final class InputLogic {
 
         if(codePoint == Constants.CODE_SPACE
                 && inputTransaction.mSpaceState == SpaceState.ANTIPHANTOM) {
+            startDoubleSpacePeriodCountdown(inputTransaction);
             return;
         }
 


### PR DESCRIPTION
Fixes #2067. Double-tapping space wasn't inserting a period after picking a suggestion. The ANTIPHANTOM guard swallows the first space to avoid duplicates, but that also skipped starting the double-space timer. I added `startDoubleSpacePeriodCountdown()` inside that guard so it triggers on the actual keypress.

Tested locally:
- Quick double-tap after suggestion → period inserts
- Pausing before double-tapping → still works