### PR TITLE
Finish voice input on D-pad center / Enter instead of canceling (Android TV)

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/Action.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Action.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -149,6 +150,14 @@ abstract class ActionWindow {
     open fun close(): CloseResult {
         return CloseResult.Default
     }
+
+    /**
+     * Called for a hardware key event while this window is open, before the event reaches focused
+     * composables in the window. This lets a window respond to e.g. a TV remote's D-pad center /
+     * Enter, where there is no touchscreen to tap the window. Return true to consume the event;
+     * the default implementation ignores all key events.
+     */
+    open fun onKeyEvent(event: KeyEvent): Boolean = false
 }
 
 interface PersistentActionState {

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -808,7 +809,7 @@ class UixManager(private val latinIME: LatinIME) {
         }
 
         val showingAboveKeyboard = !mainKeyboardHidden.value
-        Column {
+        Column(Modifier.onPreviewKeyEvent { windowImpl.onKeyEvent(it) }) {
             Column(
                 Modifier.background(
                     if (showingAboveKeyboard) {

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -13,6 +13,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -234,6 +239,22 @@ private class VoiceInputActionWindow(
         recognizerView.value?.cancel()
         state.modelManager.cancelAll()
         return CloseResult.Default
+    }
+
+    override fun onKeyEvent(event: KeyEvent): Boolean {
+        // On a device driven by a D-pad / remote (e.g. Android TV) there is no touchscreen to tap
+        // the window to finish, and the D-pad center would otherwise activate the focused "back"
+        // button in the action bar and cancel dictation. Treat center/enter as a tap on the
+        // window: finish recognition and submit the result.
+        return when (event.key) {
+            Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+                if (event.type == KeyEventType.KeyUp) {
+                    recognizerView.value?.finish()
+                }
+                true
+            }
+            else -> false
+        }
     }
 
     private var wasFinished = false


### PR DESCRIPTION
## Summary

On Android TV (and other D-pad / remote driven devices), pressing the remote's center / "OK" button while the voice input window is open **cancels** dictation instead of finishing it. There is no touchscreen to "tap" the window, so there is currently no way to end dictation and submit the result using a remote.

## Cause

On a device without a touchscreen the IME window is focusable, so the D-pad moves focus through the keyboard's Compose UI. When the voice input action window opens, initial focus lands on the **back arrow** in the action-bar header (`ActionWindowBar`, `onBack = { closeActionWindow(true) }`). Pressing D-pad center then activates that button and cancels dictation. (Tapping the window — which calls `recognizerView.finish()` — works on phones because touch bypasses focus.)

## Fix

- Add an open `ActionWindow.onKeyEvent(KeyEvent): Boolean` hook (default returns `false`).
- Invoke it from `UixManager` via `Modifier.onPreviewKeyEvent` on the action-window container, so it runs **before** the focused composable (the back button) consumes the key.
- `VoiceInputActionWindow` overrides it to treat **D-pad center / Enter / numpad Enter** as a tap on the window: finish recognition and submit the result.

Other action windows are unaffected (the default hook returns `false`, so the event propagates normally). Cancel remains available via the system Back button.

## Notes

- Reported and reproduced on an Android TV driven by a D-pad remote (the remote's OK button maps to `KEYCODE_DPAD_CENTER`). With the fix, center finishes & submits; the system Back button still cancels.
- Related to #58 (Android TV Support).
- `onPreviewKeyEvent` fires under exactly the focus condition that produces the unwanted cancel (the back button being focused), so it reliably intercepts the same event before the button does.
