### PR TITLE
Fix one-handed mirror for anchored functional keys in bottom rows

### DIFF
--- a/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/LayoutEngine.kt
@@ -547,7 +547,7 @@ data class LayoutEngine(
     private fun swapOuterKeys(entries: List<LayoutEntry>): List<LayoutEntry> {
         fun isOuter(entry: LayoutEntry): Boolean = when(entry) {
             is LayoutEntry.Gap -> true
-            is LayoutEntry.Key -> entry.data.width != KeyWidth.Regular
+            is LayoutEntry.Key -> entry.data.width != KeyWidth.Regular && entry.data.anchored
         }
 
         val leadingCount = entries.indexOfFirst { !isOuter(it) }.let { if(it == -1) entries.size else it }


### PR DESCRIPTION
The enter and symbol keys in the ClearFlow/KASROZ layouts use uses `FunctionalKey` width for all keys so the previous isOuter check (width != Regular) classified everything as outer, causing the guard `leadingCount + trailingCount >= entries.size` to bail out without swapping - leaving enter and symbols keys unmoved in left-handed mode.

The fix changes isOuter to require both non-Regular width and anchored, so only true functional keys (enter, symbols, shift, delete) are treated as outer, whilst swapping just these two keys.