### PR TITLE
fix(dictionary-facilitator): email-learning crash for incomplete/wrong emal inputs

### DIFF
--- a/java/src/org/futo/inputmethod/latin/DictionaryFacilitatorImpl.java
+++ b/java/src/org/futo/inputmethod/latin/DictionaryFacilitatorImpl.java
@@ -276,15 +276,20 @@ public class DictionaryFacilitatorImpl implements DictionaryFacilitator {
     public void onEmailTyped(String email) {
         SettingsValues settings = Settings.getInstance().getCurrent();
         if(!settings.isPersonalizationEnabled() || settings.mInputAttributes.mNoLearning) return;
-
-        if(email != null) {
-            if(email.contains("@") && email.contains(".") && mEmailDictionary != null) {
-                String domain = email.split("@")[1];
-                if(domain.contains(".")) {
-                    mEmailDictionary.addEntryNow(NgramContext.BEGINNING_OF_SENTENCE, 32, email);
-                    mEmailDictionary.addEntryNow(NgramContext.EMAIL_DOMAIN, 32, domain);
-                }
-            }
+        if (email == null) return;
+        
+        int at = email.indexOf('@');
+        if (at <= 0) return;
+        if (at != email.lastIndexOf('@')) return;
+        if (at == email.length() - 1) return;
+        
+        String domain = email.substring(at + 1);
+        if (!domain.contains(".")) return;
+        if (domain.startsWith(".") || domain.endsWith(".")) return;
+        
+        if (mEmailDictionary != null) {
+          mEmailDictionary.addEntryNow(NgramContext.BEGINNING_OF_SENTENCE, 32, email);
+          mEmailDictionary.addEntryNow(NgramContext.EMAIL_DOMAIN, 32, domain);
         }
     }
 


### PR DESCRIPTION
[rememberCommittedEmail()](https://github.com/futo-org/android-keyboard/blob/master/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java#L238) is called when input is finalized for an email field. 
Inside the class InputLogic, finishInput() calls rememberCommittedEmail() before resetting input state, and performEditorAction() also calls it before forwarding the editor action to the app via mConnection.performEditorAction(actionId).

This is expected, Android calls onFinishInputView() when the input view is hidden, either before hiding the keyboard or before switching to another editing target.

The crash is caused by the email-learning path accepting a string that merely contains both "@" and ".". It assumes that email.split("@")[1] exists in [DictionaryFacilitatorImpl.onEmailTyped()](https://github.com/futo-org/android-keyboard/blob/master/java/src/org/futo/inputmethod/latin/DictionaryFacilitatorImpl.java#L276). This assumption is unsafe because Java's one-argument String.split() discards trailing empty strings. For example, "foo.@".split("@") returns only ["foo."], so accessing index 1 throws ArrayIndexOutOfBoundsException.

## How to reproduce
- Enable FUTO Keyboard.
- Use a text field with email input type, for example inputType="textEmailAddress" (I was using thunderbird for testing it).
- Make sure personalization/learning is enabled so onEmailTyped() is not skipped.
- Type an incomplete email-like value that contains both "." and "@", but has no domain after "@", for example: "foo.@"
- Press the IME action key, such as Done/Next, or leave the field/close the keyboard.
