### PR TITLE
docs: fix transformer model docs link

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/modelmanager/ModelList.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/modelmanager/ModelList.kt
@@ -94,7 +94,7 @@ fun ModelListScreen(navController: NavHostController = rememberNavController()) 
             title = "Docs",
             style = NavigationItemStyle.Misc,
             navigate = {
-                context.openURI("https://gitlab.futo.org/alex/keyboard-wiki/-/wikis/Keyboard-LM-docs")
+                context.openURI("https://docs.keyboard.futo.org/settings/textprediction")
             }
         )
         NavigationItem(


### PR DESCRIPTION
## Summary
- update the Transformer Models settings Docs action to open the current FUTO Keyboard Text Prediction documentation
- replace the removed GitLab wiki URL that currently returns 404

Closes #2040

## Verification
- `git diff --check`
- `rg -n "Keyboard-LM-docs|docs.keyboard.futo.org/settings/textprediction" java/src/org/futo/inputmethod/latin/uix/settings/pages/modelmanager/ModelList.kt`
- curl check: old GitLab wiki URL returns 404; new docs URL returns 200