### PR TITLE
Apply shift to word suggestions

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -468,6 +468,8 @@
     <string name="typing_settings_enable_clipboard_history_tags">copy, paste</string>
     <string name="typing_settings_delete_pasted_text_on_backspace">Delete pasted/inserted text on backspace</string>
     <string name="typing_settings_revert_correction_on_backspace">Undo autocorrect on backspace</string>
+    <string name="typing_settings_apply_shift_to_suggestions">Apply shift to word suggestion</string>
+    <string name="typing_settings_apply_shift_to_suggestions_subtitle">While typing a word, press shift to show lowercase, Capitalized and ALL CAPS variants in the suggestion bar</string>
 
     <!-- Automatic space insertion -->
     <string name="typing_settings_auto_space_mode">Automatic spaces mode</string>

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -53,6 +53,8 @@ import org.futo.inputmethod.latin.settings.SettingsValues;
 import org.futo.inputmethod.latin.settings.SettingsValuesForSuggestion;
 import org.futo.inputmethod.latin.settings.SpacingAndPunctuations;
 import org.futo.inputmethod.latin.suggestions.SuggestionStripViewAccessor;
+import org.futo.inputmethod.latin.uix.DataStoreHelper;
+import org.futo.inputmethod.latin.uix.SettingsKt;
 import org.futo.inputmethod.latin.uix.actions.BugViewerKt;
 import org.futo.inputmethod.latin.utils.InputTypeUtils;
 import org.futo.inputmethod.latin.utils.RecapitalizeStatus;
@@ -135,6 +137,13 @@ public final class InputLogic {
     private String mWordBeingCorrectedByCursor = null;
 
     final ArrayDeque<RememberedSuggestedWords> mRememberedSuggestedWords = new ArrayDeque<>();
+
+    // The untransformed suggestions to use as the source for shift-case cycling
+    // in the suggestion strip. Cleared on any external suggestion update.
+    private SuggestedWords mSuggestedWordsBeforeShiftTransform = null;
+    // Guard so showing transformed suggestions via the strip accessor doesn't
+    // itself clear mSuggestedWordsBeforeShiftTransform.
+    private boolean mPushingTransformedSuggestions = false;
 
     @Nullable
     private SuggestedWords lookupSuggestedWords(int cursor, String word) {
@@ -809,6 +818,11 @@ public final class InputLogic {
     // TODO: on the long term, this method should become private, but it will be difficult.
     // Especially, how do we deal with InputMethodService.onDisplayCompletions?
     public void setSuggestedWords(final SuggestedWords suggestedWords) {
+        if (!mPushingTransformedSuggestions) {
+            // Any external suggestion update invalidates the saved pre-transform copy
+            // used by shift-cycling in the suggestion strip.
+            mSuggestedWordsBeforeShiftTransform = null;
+        }
         if(mWordComposer.isComposingWord() && !suggestedWords.isEmpty()) {
             rememberSuggestedWords(mConnection.getExpectedSelectionStart() - mWordComposer.sizeBeforeCursor(),
                     mWordComposer.getTypedWord(), suggestedWords);
@@ -917,6 +931,7 @@ public final class InputLogic {
                 if (mSuggestedWords.isPrediction()) {
                     inputTransaction.setRequiresUpdateSuggestions();
                 }
+                tryApplyShiftCaseToSuggestionStrip();
                 break;
             case Constants.CODE_CAPSLOCK:
                 // Note: Changing keyboard to shift lock state is handled in
@@ -2733,6 +2748,113 @@ public final class InputLogic {
             }
         }
         return true;
+    }
+
+    // Modes for buildCaseTransformedSuggestions
+    private static final int CASE_TRANSFORM_NONE = 0;
+    private static final int CASE_TRANSFORM_CAPITALIZED = 1;
+    private static final int CASE_TRANSFORM_UPPER = 2;
+
+    /**
+     * If the user is composing a word and the "apply shift to word suggestion"
+     * setting is enabled, replace the suggestion strip with case-transformed
+     * variants of the current suggestions, matching the keyboard's shift state:
+     * original when shift is off, Capitalized on single shift, ALL CAPS on
+     * caps lock. The underlying {@link #mSuggestedWords} state is not mutated,
+     * so the next non-shift event resumes normal suggestions.
+     */
+    private void tryApplyShiftCaseToSuggestionStrip() {
+        if (!mWordComposer.isComposingWord()) {
+            mSuggestedWordsBeforeShiftTransform = null;
+            return;
+        }
+
+        final boolean enabled;
+        try {
+            enabled = DataStoreHelper.getSetting(SettingsKt.getAPPLY_SHIFT_TO_SUGGESTIONS());
+        } catch (final Throwable t) {
+            // Defensive: if DataStore isn't ready, behave as if disabled.
+            return;
+        }
+        if (!enabled) return;
+
+        // The "source" is the most recent untransformed suggestion set. If a
+        // previous shift press already replaced the strip, fall back to the
+        // saved copy rather than re-transforming an already-transformed list.
+        final SuggestedWords source = (mSuggestedWordsBeforeShiftTransform != null)
+                ? mSuggestedWordsBeforeShiftTransform
+                : mSuggestedWords;
+        if (source == null || source.isEmpty()) return;
+
+        final int shiftMode = mImeHelper.getKeyboardShiftMode();
+        final int caseMode;
+        switch (shiftMode) {
+            case WordComposer.CAPS_MODE_MANUAL_SHIFTED:
+            case WordComposer.CAPS_MODE_AUTO_SHIFTED:
+                caseMode = CASE_TRANSFORM_CAPITALIZED;
+                break;
+            case WordComposer.CAPS_MODE_MANUAL_SHIFT_LOCKED:
+            case WordComposer.CAPS_MODE_AUTO_SHIFT_LOCKED:
+                caseMode = CASE_TRANSFORM_UPPER;
+                break;
+            default:
+                caseMode = CASE_TRANSFORM_NONE;
+                break;
+        }
+
+        final SuggestedWords toDisplay;
+        if (caseMode == CASE_TRANSFORM_NONE) {
+            toDisplay = source;
+            mSuggestedWordsBeforeShiftTransform = null;
+        } else {
+            toDisplay = buildCaseTransformedSuggestions(source,
+                    getDictionaryFacilitatorLocale(), caseMode);
+            if (mSuggestedWordsBeforeShiftTransform == null) {
+                mSuggestedWordsBeforeShiftTransform = source;
+            }
+        }
+
+        mPushingTransformedSuggestions = true;
+        try {
+            mSuggestionStripViewAccessor.showSuggestionStrip(toDisplay);
+        } finally {
+            mPushingTransformedSuggestions = false;
+        }
+    }
+
+    private static SuggestedWords buildCaseTransformedSuggestions(
+            final SuggestedWords source, final Locale locale, final int caseMode) {
+        final ArrayList<SuggestedWordInfo> list = new ArrayList<>(source.size());
+        for (int i = 0; i < source.size(); i++) {
+            list.add(transformSuggestedWordInfo(source.getInfo(i), locale, caseMode));
+        }
+        final SuggestedWordInfo typed = source.getTypedWordInfo();
+        final SuggestedWordInfo transformedTyped = (typed == null)
+                ? null : transformSuggestedWordInfo(typed, locale, caseMode);
+        return new SuggestedWords(list, null, transformedTyped,
+                source.mTypedWordValid, source.mWillAutoCorrect,
+                source.mIsObsoleteSuggestions, source.mInputStyle, source.mSequenceNumber);
+    }
+
+    private static SuggestedWordInfo transformSuggestedWordInfo(
+            final SuggestedWordInfo info, final Locale locale, final int caseMode) {
+        final String original = info.mWord;
+        if (original == null || original.isEmpty()) return info;
+        final String transformed;
+        switch (caseMode) {
+            case CASE_TRANSFORM_UPPER:
+                transformed = original.toUpperCase(locale);
+                break;
+            case CASE_TRANSFORM_CAPITALIZED:
+                transformed = StringUtils.capitalizeFirstAndDowncaseRest(original, locale);
+                break;
+            default:
+                return info;
+        }
+        if (transformed.equals(original)) return info;
+        return new SuggestedWordInfo(transformed, info.mPrevWordsContext, info.mScore,
+                info.mKindAndFlags, info.mSourceDict,
+                info.mIndexOfTouchPointOfSecondWord, info.mAutoCommitFirstWordConfidence);
     }
 
     /**

--- a/java/src/org/futo/inputmethod/latin/uix/Settings.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Settings.kt
@@ -388,3 +388,8 @@ val SHOW_EMOJI_SUGGESTIONS = SettingsKey(
     key = booleanPreferencesKey("suggestEmojis"),
     default = true
 )
+
+val APPLY_SHIFT_TO_SUGGESTIONS = SettingsKey(
+    key = booleanPreferencesKey("applyShiftToSuggestions"),
+    default = false
+)

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -99,6 +99,7 @@ import org.futo.inputmethod.latin.uix.AndroidTextInput
 import org.futo.inputmethod.latin.uix.BasicThemeProvider
 import org.futo.inputmethod.latin.uix.KeyHintsSetting
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
+import org.futo.inputmethod.latin.uix.APPLY_SHIFT_TO_SUGGESTIONS
 import org.futo.inputmethod.latin.uix.SHOW_EMOJI_SUGGESTIONS
 import org.futo.inputmethod.latin.uix.SettingsKey
 import org.futo.inputmethod.latin.uix.getSettingBlocking
@@ -879,6 +880,11 @@ val TypingSettingsMenu = UserSettingsMenu(
             icon = {
                 Text("Aa", style = Typography.Body.MediumMl, color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f))
             }
+        ),
+        userSettingToggleDataStore(
+            title = R.string.typing_settings_apply_shift_to_suggestions,
+            subtitle = R.string.typing_settings_apply_shift_to_suggestions_subtitle,
+            setting = APPLY_SHIFT_TO_SUGGESTIONS,
         ),
         userSettingToggleSharedPrefs(
             title = R.string.use_double_space_period,


### PR DESCRIPTION
Contribution to implement requested feature #1693

When the user presses shift while a word is in the suggestion strip, replace the suggestions with case-transformed variants matching the new shift state: Capitalized on single shift, ALL CAPS on caps lock, original when shift is off. Tapping a suggestion commits it in place.

Feature can be enabled by a new "Apply shift to word suggestion" toggle in the Typing preferences (default off).