### PR TITLE
unfocusAudio before starting to process audio

### DIFF
--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -587,6 +587,8 @@ class AudioRecognizer(
         isRecording = false
         recorder?.stop()
 
+        unfocusAudio()
+
         listener.processing()
 
         modelJob = lifecycleScope.launch {


### PR DESCRIPTION
Currently if you are trying to transcribe some text while you're listening to something, obv the media pauses. But it seems to only unpause AFTER processing is done... which doesn't make sense to me; it should resume media when it's done recording.


I HAVE NOT TESTED THIS CHANGE (because I was having issues with android sdk rn) but this might be a correct change?