### PR TITLE
feat: Add spacebar language-swipe sensitivity setting

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -440,6 +440,11 @@
     <string name="morekey_settings_spacebar_hold_shortcut">Hold</string>
     <string name="morekey_settings_spacebar_hold_shortcut_cursor">Move cursor</string>
     <string name="morekey_settings_spacebar_hold_shortcut_language">Switch language</string>
+    <string name="morekey_settings_spacebar_language_swipe_distance">Language swipe distance</string>
+    <string name="morekey_settings_spacebar_language_swipe_distance_subtitle">Shorter distance makes the language swipe more sensitive</string>
+
+    <!-- Units abbreviation for a distance in density-independent pixels [CHAR LIMIT=10] -->
+    <string name="abbreviation_unit_dp"><xliff:g id="DPI">%s</xliff:g>dp</string>
 
     <!-- Types of morekeys that can be configured, and examples of them -->
     <string name="morekey_settings_kind_numbers">Numbers</string>

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -19,6 +19,7 @@ package org.futo.inputmethod.keyboard;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.SystemClock;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.MotionEvent;
 
@@ -97,10 +98,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private static PointerTrackerParams sParams;
     private static final int sPointerStep = (int)(16.0 * Resources.getSystem().getDisplayMetrics().density);
     private static final int sPointerBigStep = (int)(32.0 * Resources.getSystem().getDisplayMetrics().density);
-    private static final int sPointerHugeStep = Integer.min(
-            (int)(128.0 * Resources.getSystem().getDisplayMetrics().density),
-            Resources.getSystem().getDisplayMetrics().widthPixels * 3 / 2
-    );
 
     private static GestureStrokeRecognitionParams sGestureStrokeRecognitionParams;
     private static GestureStrokeDrawingParams sGestureStrokeDrawingParams;
@@ -976,7 +973,14 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             if(allowedBySettings) {
                 int pointerStep = sPointerStep;
                 if (settingsValues.mSpacebarSwipeMode == Settings.SPACEBAR_MODE_LANGUAGE && !mSpacebarLongPressed) {
-                    pointerStep = sPointerHugeStep;
+                    // The language-switch step distance is user-configurable in dp. The
+                    // widthPixels*3/2 clamp is a safety bound for narrow screens.
+                    final DisplayMetrics displayMetrics =
+                            Resources.getSystem().getDisplayMetrics();
+                    pointerStep = Integer.min(
+                            (int)(settingsValues.mSpacebarLanguageSwipeStepDp * displayMetrics.density),
+                            displayMetrics.widthPixels * 3 / 2
+                    );
                 }
 
                 int steps = (x - mStartX) / pointerStep;

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -154,6 +154,9 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private boolean mStartedOnFastLongPress;
     private boolean mCursorMoved = false;
     private boolean mSpacebarLongPressed = false;
+    // A spacebar language swipe may only switch the language once per gesture, regardless of how
+    // far the finger travels. Changing two languages requires lifting and swiping again.
+    private boolean mLanguageSwiped = false;
 
     // true if keyboard layout has been changed.
     private boolean mKeyboardLayoutHasBeenChanged;
@@ -757,6 +760,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             mStartTime = System.currentTimeMillis();
             mStartedOnFastLongPress = key.isFastLongPress();
             mSpacebarLongPressed = false;
+            mLanguageSwiped = false;
 
             mIsSlidingCursor = key.getCode() == Constants.CODE_DELETE || key.getCode() == Constants.CODE_SPACE;
             mIsFlickingKey = !mIsSlidingCursor && key.getHasFlick();
@@ -990,7 +994,12 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                     mStartX += steps * pointerStep;
 
                     if (settingsValues.mSpacebarSwipeMode == Settings.SPACEBAR_MODE_LANGUAGE && !mSpacebarLongPressed) {
-                        sListener.onSwipeLanguage(steps);
+                        // Cap the switch at one language per gesture, in the swipe's direction,
+                        // independent of swipe distance/sensitivity.
+                        if (!mLanguageSwiped) {
+                            mLanguageSwiped = true;
+                            sListener.onSwipeLanguage(Integer.signum(steps));
+                        }
                     } else {
                         sListener.onMovePointer(steps);
                     }

--- a/java/src/org/futo/inputmethod/latin/settings/Settings.java
+++ b/java/src/org/futo/inputmethod/latin/settings/Settings.java
@@ -137,6 +137,12 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final int SPACEBAR_MODE_CURSOR = 1;
     public static final int SPACEBAR_MODE_LANGUAGE = 2;
 
+    // Per-step horizontal swipe distance (in dp) required to advance one language when the
+    // spacebar swipe mode is LANGUAGE. Default keeps the original hardcoded 128dp behaviour.
+    public static final String PREF_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY =
+            "pref_spacebar_language_swipe_sensitivity";
+    public static final int DEFAULT_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY = 128;
+
     public static final String PREF_BACKSPACE_MODE_HOLD = "pref_backspace_mode_hold";
     public static final String PREF_BACKSPACE_MODE = "pref_backspace_mode";
     public static final int BACKSPACE_MODE_CHARACTERS = 0; // Long-press backspace and swipe backspace removes just characters

--- a/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
@@ -108,6 +108,7 @@ public class SettingsValues {
     public final boolean mBackspaceUndoesAutocorrect;
     public final int mSpacebarSwipeMode;
     public final int mSpacebarHoldMode;
+    public final int mSpacebarLanguageSwipeStepDp;
     public final int mBackspaceMode;
     public final int mBackspaceModeHold;
     public final int mNumberRowMode;
@@ -209,6 +210,8 @@ public class SettingsValues {
                 legacySpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE_LEGACY ? Settings.SPACEBAR_MODE_LANGUAGE : Settings.SPACEBAR_MODE_CURSOR);
         mSpacebarHoldMode = prefs.getInt(Settings.PREF_SPACEBAR_HOLD_MODE,
                 legacySpacebarMode == Settings.SPACEBAR_MODE_SWIPE_CURSOR_LEGACY ? Settings.SPACEBAR_MODE_LANGUAGE : Settings.SPACEBAR_MODE_CURSOR);
+        mSpacebarLanguageSwipeStepDp = prefs.getInt(Settings.PREF_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY,
+                Settings.DEFAULT_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY);
 
         mBackspaceMode = prefs.getInt(Settings.PREF_BACKSPACE_MODE, Settings.BACKSPACE_MODE_CHARACTERS);
         mBackspaceModeHold = prefs.getInt(Settings.PREF_BACKSPACE_MODE_HOLD, mBackspaceMode);
@@ -580,6 +583,8 @@ public class SettingsValues {
         sb.append("" + mBackspaceUndoesAutocorrect);
         sb.append("\n   mBackspaceMode = ");
         sb.append("" + mBackspaceMode);
+        sb.append("\n   mSpacebarLanguageSwipeStepDp = ");
+        sb.append("" + mSpacebarLanguageSwipeStepDp);
         sb.append("\n   mNumberRowMode = ");
         sb.append("" + mNumberRowMode);
         sb.append("\n   mAltSpacesMode = ");

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -636,6 +636,24 @@ val LongPressMenu = UserSettingsMenu(
             )
         },
 
+        UserSetting(
+            name = R.string.morekey_settings_spacebar_language_swipe_distance,
+            subtitle = R.string.morekey_settings_spacebar_language_swipe_distance_subtitle,
+        ) {
+            val resources = LocalResources.current
+            SettingSliderSharedPrefsInt(
+                title = stringResource(R.string.morekey_settings_spacebar_language_swipe_distance),
+                subtitle = stringResource(R.string.morekey_settings_spacebar_language_swipe_distance_subtitle),
+                key = Settings.PREF_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY,
+                default = Settings.DEFAULT_SPACEBAR_LANGUAGE_SWIPE_SENSITIVITY,
+                range = 24.0f..160.0f,
+                hardRange = 24.0f..160.0f,
+                transform = { it.roundToInt() },
+                indicator = { resources.getString(R.string.abbreviation_unit_dp, "$it") },
+                steps = 16
+            )
+        },
+
         // TODO: Might not work well for showing up in search
         UserSetting(name = R.string.morekey_settings_layout) {
             val context = LocalContext.current


### PR DESCRIPTION
The spacebar language-switch swipe used a hardcoded 128dp step. I exposed it as an adjustable distance on the Spacebar settings screen with an 128dp default.