### PR TITLE
Collapse multilingual subtypes by keyboard layout

### DIFF
--- a/java/src/org/futo/inputmethod/keyboard/MainKeyboardView.java
+++ b/java/src/org/futo/inputmethod/keyboard/MainKeyboardView.java
@@ -52,6 +52,7 @@ import org.futo.inputmethod.keyboard.internal.NonDistinctMultitouchHelper;
 import org.futo.inputmethod.keyboard.internal.SlidingKeyInputDrawingPreview;
 import org.futo.inputmethod.keyboard.internal.TimerHandler;
 import org.futo.inputmethod.latin.AudioAndHapticFeedbackManager;
+import org.futo.inputmethod.latin.RichInputMethodManager;
 import org.futo.inputmethod.latin.uix.DynamicThemeProvider;
 import org.futo.inputmethod.latin.R;
 import org.futo.inputmethod.latin.SuggestedWords;
@@ -875,6 +876,25 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
         return "";
     }
 
+    private String layoutMultilingualLanguagesOnSpacebar(final List<Locale> locales) {
+        final StringBuilder builder = new StringBuilder();
+
+        for (final Locale locale : locales) {
+            final String language = locale.getLanguage();
+            if (language == null || language.isEmpty()) {
+                continue;
+            }
+
+            if (builder.length() > 0) {
+                builder.append('/');
+            }
+
+            builder.append(language.toUpperCase(Locale.ROOT));
+        }
+
+        return builder.toString();
+    }
+
     private void drawLanguageOnSpacebar(final Key key, final Canvas canvas, final Paint paint, final int color) {
         final Keyboard keyboard = getKeyboard();
         if (keyboard == null) {
@@ -885,7 +905,10 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
         paint.setTextAlign(Align.CENTER);
         paint.setTypeface(mDrawableProvider.selectKeyTypeface(Typeface.DEFAULT));
         paint.setTextSize(mLanguageOnSpacebarTextSize);
-        final String language = layoutLanguageOnSpacebar(paint, keyboard.mId.mLocale, width);
+        final List<Locale> currentSubtypeLocales = RichInputMethodManager.getInstance().getCurrentSubtypeLocales();
+        final String language = currentSubtypeLocales.size() > 1
+                ? layoutMultilingualLanguagesOnSpacebar(currentSubtypeLocales)
+                : layoutLanguageOnSpacebar(paint, keyboard.mId.mLocale, width);
         // Draw language text with shadow
         final float descent = paint.descent();
         final float textHeight = -paint.ascent() + descent;

--- a/java/src/org/futo/inputmethod/latin/RichInputMethodSubtype.java
+++ b/java/src/org/futo/inputmethod/latin/RichInputMethodSubtype.java
@@ -164,7 +164,7 @@ public class RichInputMethodSubtype {
 
     @Nonnull
     public List<Locale> getMultilingualTypingLanguages(Context context) {
-        return Subtypes.INSTANCE.getMultilingualBucket(context, mLocale);
+        return Subtypes.INSTANCE.getMultilingualBucket(context, mLocale, getKeyboardLayoutSetName());
     }
 
     public static RichInputMethodSubtype getRichInputMethodSubtype(

--- a/java/src/org/futo/inputmethod/latin/Subtypes.kt
+++ b/java/src/org/futo/inputmethod/latin/Subtypes.kt
@@ -172,7 +172,7 @@ object Subtypes {
     }
 
     fun hasMultipleEnabledSubtypes(context: Context): Boolean {
-        return context.getSettingBlocking(SubtypesSetting).size > 1
+        return getSwitchableSubtypes(context).size > 1
     }
 
     fun subtypeToString(subtype: InputMethodSubtype): String {
@@ -255,6 +255,83 @@ object Subtypes {
         }
     }
 
+    private fun InputMethodSubtype.layoutSetName(): String =
+        SubtypeLocaleUtils.getKeyboardLayoutSetName(this)
+
+    private fun multilingualBucketLocales(multilingualBucket: Set<String>): Set<Locale> =
+        multilingualBucket.map { getLocale(it) }.toSet()
+
+    private fun multilingualGroupKey(
+        subtype: InputMethodSubtype,
+        enabledSubtypes: List<InputMethodSubtype>,
+        multilingualBucket: Set<Locale>
+    ): String {
+        val locale = getLocale(subtype)
+        val layout = subtype.layoutSetName()
+
+        val localesInSameLayoutBucket = enabledSubtypes.asSequence()
+            .filter { it.layoutSetName() == layout }
+            .map { getLocale(it) }
+            .filter { multilingualBucket.contains(it) }
+            .distinct()
+            .sortedBy { it.toLanguageTag() }
+            .toList()
+
+        return if(multilingualBucket.contains(locale) && localesInSameLayoutBucket.size > 1) {
+            "multilingual:$layout:${localesInSameLayoutBucket.joinToString(";") { it.toLanguageTag() }}"
+        } else {
+            "single:${subtypeToString(subtype)}"
+        }
+    }
+
+    fun getSwitchableSubtypes(context: Context): List<InputMethodSubtype> =
+        getSwitchableSubtypes(
+            context.getSettingBlocking(SubtypesSetting),
+            context.getSettingBlocking(MultilingualBucketSetting)
+        )
+
+    fun getSwitchableSubtypes(
+        subtypeSet: Set<String>,
+        multilingualBucketSet: Set<String>
+    ): List<InputMethodSubtype> {
+        val enabledSubtypes = subtypeSet.map { convertToSubtype(it) }
+        val multilingualBucket = multilingualBucketLocales(multilingualBucketSet)
+        val seen = mutableSetOf<String>()
+
+        return enabledSubtypes.filter { subtype ->
+            seen.add(multilingualGroupKey(subtype, enabledSubtypes, multilingualBucket))
+        }
+    }
+
+    fun isSameSwitchableSubtype(
+        subtypeSet: Set<String>,
+        multilingualBucketSet: Set<String>,
+        firstSubtype: String,
+        secondSubtype: InputMethodSubtype
+    ): Boolean {
+        if(firstSubtype.isEmpty()) return false
+        if(firstSubtype == subtypeToString(secondSubtype)) return true
+
+        val enabledSubtypes = subtypeSet.map { convertToSubtype(it) }
+        val multilingualBucket = multilingualBucketLocales(multilingualBucketSet)
+        val first = convertToSubtype(firstSubtype)
+
+        return multilingualGroupKey(first, enabledSubtypes, multilingualBucket) ==
+                multilingualGroupKey(secondSubtype, enabledSubtypes, multilingualBucket)
+    }
+
+    fun getSwitchableSubtypeDisplayName(
+        context: Context,
+        subtype: InputMethodSubtype
+    ): String {
+        val locale = getLocale(subtype)
+        val locales = listOf(locale) + getMultilingualBucket(context, locale, subtype.layoutSetName())
+
+        return locales.distinct().joinToString(" / ") {
+            getLocaleDisplayName(it, it)
+        }
+    }
+
     fun getDirectBootInitialLayouts(context: Context): Set<String> {
         val layouts = mutableSetOf("en_US:")
 
@@ -284,7 +361,7 @@ object Subtypes {
     ): Boolean {
         if(direction == 0) return true
 
-        val enabledSubtypes = context.getSettingBlocking(SubtypesSetting).toList()
+        val enabledSubtypes = getSwitchableSubtypes(context).map { subtypeToString(it) }
         val currentSubtype = context.getSettingBlocking(ActiveSubtype)
 
         if(enabledSubtypes.isEmpty()) return false
@@ -293,7 +370,23 @@ object Subtypes {
             return false
         }
 
-        val index = enabledSubtypes.indexOf(currentSubtype)
+        val allSubtypes = context.getSettingBlocking(SubtypesSetting)
+        val multilingualBucket = context.getSettingBlocking(MultilingualBucketSetting)
+
+        val index = enabledSubtypes.indexOf(currentSubtype).let { directIndex ->
+            if(directIndex != -1) {
+                directIndex
+            } else {
+                enabledSubtypes.indexOfFirst {
+                    isSameSwitchableSubtype(
+                        allSubtypes,
+                        multilingualBucket,
+                        currentSubtype,
+                        convertToSubtype(it)
+                    )
+                }
+            }
+        }
         val nextIndex = if(index == -1) {
             0
         } else {
@@ -304,14 +397,30 @@ object Subtypes {
         return true
     }
 
-    fun getMultilingualBucket(context: Context, locale: Locale): List<Locale> {
-        val set = context.getSetting(MultilingualBucketSetting).map {
-            getLocale(it)
-        }
+    @JvmOverloads
+    fun getMultilingualBucket(
+        context: Context,
+        locale: Locale,
+        keyboardLayoutSet: String? = null
+    ): List<Locale> {
+        val set = multilingualBucketLocales(context.getSetting(MultilingualBucketSetting))
         if(!set.contains(locale)) {
             return emptyList()
         } else {
-            return set.filter { it != locale }
+            val enabledLocales = if(keyboardLayoutSet != null) {
+                context.getSettingBlocking(SubtypesSetting)
+                    .asSequence()
+                    .map { convertToSubtype(it) }
+                    .filter { it.layoutSetName() == keyboardLayoutSet }
+                    .map { getLocale(it) }
+                    .filter { set.contains(it) }
+                    .distinct()
+                    .toList()
+            } else {
+                set.toList()
+            }
+
+            return enabledLocales.filter { it != locale }
         }
     }
 }
@@ -331,11 +440,15 @@ fun LanguageSwitcherDialog(
         useDataStoreValue(SubtypesSetting)
     }
 
-    val subtypes = remember(subtypeSet) {
-        Subtypes.layoutsMappedByLanguage(subtypeSet)
+    val multilingualBucketSet = if(inspection) {
+        setOf("en_US", "pt_PT")
+    } else {
+        useDataStoreValue(MultilingualBucketSetting)
     }
 
-    val keys = remember(subtypes) { subtypes.keys.toList().sorted() }
+    val subtypes = remember(subtypeSet, multilingualBucketSet) {
+        Subtypes.getSwitchableSubtypes(subtypeSet, multilingualBucketSet)
+    }
 
     val activeSubtype = if(inspection) {
         "pt_PT:KeyboardLayoutSet=portugues:"
@@ -372,42 +485,45 @@ fun LanguageSwitcherDialog(
             )
 
             LazyColumn(modifier = Modifier.weight(1.0f)) {
-                items(keys) { locale ->
-                    subtypes[locale]!!.forEach { subtype ->
-                        val layoutSetName = subtype.getExtraValueOf(Constants.Subtype.ExtraValue.KEYBOARD_LAYOUT_SET) ?: ""
+                items(subtypes) { subtype ->
+                    val layoutSetName = subtype.getExtraValueOf(Constants.Subtype.ExtraValue.KEYBOARD_LAYOUT_SET) ?: ""
 
-                        val layout = if(inspection) { layoutSetName } else { Subtypes.getLayoutName(context, layoutSetName) }
-                        val title = if(inspection) { subtype.locale } else { Subtypes.getName(subtype) }
+                    val layout = if(inspection) { layoutSetName } else { Subtypes.getLayoutName(context, layoutSetName) }
+                    val title = if(inspection) { subtype.locale } else { Subtypes.getSwitchableSubtypeDisplayName(context, subtype) }
 
-                        val selected = activeSubtype == Subtypes.subtypeToString(subtype)
+                    val selected = Subtypes.isSameSwitchableSubtype(
+                        subtypeSet,
+                        multilingualBucketSet,
+                        activeSubtype,
+                        subtype
+                    )
 
-                        val item = @Composable {
-                            NavigationItem(
-                                title = title,
-                                subtitle = layout.ifBlank { null },
-                                style = NavigationItemStyle.MiscNoArrow,
-                                navigate = {
-                                    context.setSettingBlocking(ActiveSubtype.key, Subtypes.subtypeToString(subtype))
-                                    onDismiss()
-                                },
-                                icon = if(selected) painterResource(R.drawable.check_circle) else painterResource(R.drawable.circle)
-                            )
-                        }
+                    val item = @Composable {
+                        NavigationItem(
+                            title = title,
+                            subtitle = layout.ifBlank { null },
+                            style = NavigationItemStyle.MiscNoArrow,
+                            navigate = {
+                                context.setSettingBlocking(ActiveSubtype.key, Subtypes.subtypeToString(subtype))
+                                onDismiss()
+                            },
+                            icon = if(selected) painterResource(R.drawable.check_circle) else painterResource(R.drawable.circle)
+                        )
+                    }
 
-                        if (selected) {
-                            Surface(color = MaterialTheme.colorScheme.primary) {
-                                CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onPrimary) {
-                                    item()
-                                }
+                    if (selected) {
+                        Surface(color = MaterialTheme.colorScheme.primary) {
+                            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onPrimary) {
+                                item()
                             }
-                        } else {
-                            item()
                         }
+                    } else {
+                        item()
                     }
                 }
 
                 item {
-                    if(activeIMEs.isNotEmpty() && keys.isNotEmpty()) {
+                    if(activeIMEs.isNotEmpty() && subtypes.isNotEmpty()) {
                         Spacer(Modifier.height(16.dp))
                         HorizontalDivider()
                         Spacer(Modifier.height(16.dp))

--- a/java/src/org/futo/inputmethod/latin/SwipeDecoderDictionary.kt
+++ b/java/src/org/futo/inputmethod/latin/SwipeDecoderDictionary.kt
@@ -319,6 +319,7 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
     }
 
     var decoder: SwipeDecoder? = null
+    private var decoderUnavailable = false
 
     object BeamValues {
         const val shortBeam = 32
@@ -327,19 +328,29 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
         const val highestBeam = 300
     }
 
-    private fun getOrInitDecoder(): SwipeDecoder = decoder ?: run {
-        val swipeModelPath = getFilePath(context, SWIPE_MODEL)
+    private fun getOrInitDecoder(): SwipeDecoder? {
+        if(decoderUnavailable) return null
 
-        val decoder = SwipeDecoder(
-            encoderPath = swipeModelPath,
-            beamWidth = BeamValues.highestBeam,
-            useExpansion = false, // ITrie contains expanded entries already
-        )
+        return decoder ?: run {
+            val swipeModelPath = getFilePath(context, SWIPE_MODEL)
 
-        this.decoder = decoder
-        applyPendingLayoutInfo()
+            try {
+                val decoder = SwipeDecoder(
+                    encoderPath = swipeModelPath,
+                    beamWidth = BeamValues.highestBeam,
+                    useExpansion = false, // ITrie contains expanded entries already
+                )
 
-        return decoder
+                this.decoder = decoder
+                applyPendingLayoutInfo()
+
+                if(decoderUnavailable) null else decoder
+            } catch(e: RuntimeException) {
+                Log.e("SwipeDecoderDictionary", "Failed to initialize swipe decoder", e)
+                decoderUnavailable = true
+                null
+            }
+        }
     }
 
     override fun getNextValidCodePoints(composedData: ComposedData?): ArrayList<Int> {
@@ -352,7 +363,7 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
     ): ArrayList<SuggestedWords.SuggestedWordInfo>? {
         if(true) return null
 
-        val decoder = getOrInitDecoder()
+        val decoder = getOrInitDecoder() ?: return null
         val wordsContext = ngramContext?.fullContext?.split(' ')?.takeLast(10) ?: emptyList()
         decoder.setContext(wordsContext)
 
@@ -446,7 +457,7 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
             ?.takeLast(10)
             ?: emptyList()
 
-        val decoder = getOrInitDecoder()
+        val decoder = getOrInitDecoder() ?: return null
         decoder.setContext(wordsContext)
         appliedTrieWeights = trieWeights
 
@@ -459,17 +470,24 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
 
         val topK = if(useHighBeam) 4 else 1
 
-        val results = synchronized(BinaryDictionary.sTrieUsageLock) {
-            if(appliedTries?.isEmpty() != false) {
-                Log.e("SwipeDecoderDictionary", "Applied tries are blank! $appliedTries")
-                return null
+        val results = try {
+            synchronized(BinaryDictionary.sTrieUsageLock) {
+                if(appliedTries?.isEmpty() != false) {
+                    Log.e("SwipeDecoderDictionary", "Applied tries are blank! $appliedTries")
+                    return null
+                }
+                decoder.recognize(
+                     left.toTypedArray(), right.toTypedArray(),
+                     topK = topK,
+                     beamWidth = beamWidth,
+                     trieWeights = trieWeights
+                )
             }
-            decoder.recognize(
-                 left.toTypedArray(), right.toTypedArray(),
-                 topK = topK,
-                 beamWidth = beamWidth,
-                 trieWeights = trieWeights
-            )
+        } catch(e: RuntimeException) {
+            Log.e("SwipeDecoderDictionary", "Swipe recognition failed", e)
+            decoderUnavailable = true
+            this.decoder = null
+            return null
         }
 
         // basically update it at end of swiping
@@ -526,18 +544,24 @@ class SwipeDecoderDictionary(val context: Context, val locale: Locale) : Diction
         decoder?.let { d ->
             pendingLayoutInfo?.let { pend ->
                 //Log.d("SwipeDecoderDictionary", "Applying layout info: $pend")
-                d.setMode(
-                    letters=pend.layout.letters,
-                    cx=pend.layout.xs.toFloatArray(),
-                    cy=pend.layout.ys.toFloatArray(),
-                    tries=pend.tries.toLongArray(),
-                    decoderPath=getFilePath(context, pend.layout.decoder),
-                    lmModelPath=getFilePath(context, pend.layout.lm),
-                    lmVocabPath=getFilePath(context, vocabFor(pend.layout.lm))
-                )
-                appliedScoring.value = d.scoring
-                appliedLayoutInfo = pend.layout
-                appliedTries = pend.tries.toLongArray()
+                try {
+                    d.setMode(
+                        letters=pend.layout.letters,
+                        cx=pend.layout.xs.toFloatArray(),
+                        cy=pend.layout.ys.toFloatArray(),
+                        tries=pend.tries.toLongArray(),
+                        decoderPath=getFilePath(context, pend.layout.decoder),
+                        lmModelPath=getFilePath(context, pend.layout.lm),
+                        lmVocabPath=getFilePath(context, vocabFor(pend.layout.lm))
+                    )
+                    appliedScoring.value = d.scoring
+                    appliedLayoutInfo = pend.layout
+                    appliedTries = pend.tries.toLongArray()
+                } catch(e: RuntimeException) {
+                    Log.e("SwipeDecoderDictionary", "Failed to apply swipe decoder layout", e)
+                    decoderUnavailable = true
+                    this.decoder = null
+                }
             }
             pendingLayoutInfo = null
         }

--- a/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
@@ -35,6 +35,7 @@ import org.futo.inputmethod.latin.uix.actions.RegistryKt;
 import org.futo.inputmethod.latin.utils.AsyncResultHolder;
 import org.futo.inputmethod.latin.utils.ResourceUtils;
 import org.futo.inputmethod.latin.utils.ScriptUtils2;
+import org.futo.inputmethod.latin.utils.SubtypeLocaleUtils;
 import org.futo.inputmethod.latin.utils.TargetPackageInfoGetterTask;
 
 import java.util.Arrays;
@@ -271,7 +272,10 @@ public class SettingsValues {
                 prefs, DebugSettings.PREF_KEY_PREVIEW_DISMISS_END_Y_SCALE,
                 defaultKeyPreviewDismissEndScale);
 
-        mMultilingualLocales = Subtypes.INSTANCE.getMultilingualBucket(context, mLocale);
+        final String currentKeyboardLayoutSet = SubtypeLocaleUtils.getKeyboardLayoutSetName(
+                Subtypes.INSTANCE.getActiveSubtype(context));
+        mMultilingualLocales = Subtypes.INSTANCE.getMultilingualBucket(
+                context, mLocale, currentKeyboardLayoutSet);
 
         mDisplayOrientation = res.getConfiguration().orientation;
         mAppWorkarounds = new AsyncResultHolder<>("AppWorkarounds");


### PR DESCRIPTION
combine languages that use the same layout and have multilingual typing enabled.

(PR written by 5.5 extended thinking)

## Technical details

- Treat switchable subtypes with the same layout as one entry
- Show combined multilingual labels on the spacebar and subtype picker
- Keep multilingual locale lists scoped to the active keyboard layout

fix #1172 (it removes the duplicate layout)
fix #1533
