### PR TITLE
Show autocorrect suggestions when using a hardware keyboard

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -501,7 +501,7 @@
     <string name="keyboard_settings_number_row_dont_use_script_digits">Always use Western numerals</string>
 
     <string name="keyboard_settings_hide_when_hardware_keyboard_is_connected">Hide when USB keyboard is detected</string>
-    <string name="keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected">Show toolbar when USB keyboard is detected</string>
+    <string name="keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected">Show toolbar when hardware keyboard is detected</string>
     <string name="keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected_subtitle">When the keyboard is hidden because a physical keyboard is connected, keep the action/suggestions bar visible and add a button to show the touch keyboard.</string>
     <string name="keyboard_actionbar_show_touch_keyboard">Show touch keyboard</string>
     <string name="keyboard_actionbar_hide_touch_keyboard">Hide touch keyboard</string>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -501,6 +501,10 @@
     <string name="keyboard_settings_number_row_dont_use_script_digits">Always use Western numerals</string>
 
     <string name="keyboard_settings_hide_when_hardware_keyboard_is_connected">Hide when USB keyboard is detected</string>
+    <string name="keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected">Show toolbar when USB keyboard is detected</string>
+    <string name="keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected_subtitle">When the keyboard is hidden because a physical keyboard is connected, keep the action/suggestions bar visible and add a button to show the touch keyboard.</string>
+    <string name="keyboard_actionbar_show_touch_keyboard">Show touch keyboard</string>
+    <string name="keyboard_actionbar_hide_touch_keyboard">Hide touch keyboard</string>
 
     <!-- misc titles -->
     <string name="settings_keyboard_typing_title">Keyboard &amp; Typing</string>

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -119,6 +119,11 @@ val HideKeyboardWhenHardKeyboardConnected = SettingsKey(
     false
 )
 
+val ShowToolbarWhenHardKeyboardConnected = SettingsKey(
+    booleanPreferencesKey("showToolbarWhenHardKeyboardConnected"),
+    false
+)
+
 private class UnlockedBroadcastReceiver(val onDeviceUnlocked: () -> Unit) : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent?.action == Intent.ACTION_USER_UNLOCKED) {
@@ -425,6 +430,19 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
 
         launchJob {
             combine(
+                getSettingFlow(HideKeyboardWhenHardKeyboardConnected),
+                getSettingFlow(ShowToolbarWhenHardKeyboardConnected)
+            ) { _, _ -> Unit }.collect {
+                withContext(Dispatchers.Main) {
+                    uixManager.refreshHardwareToolbarMode()
+                    updateInputViewShown()
+                    onSizeMaybeUpdated()
+                }
+            }
+        }
+
+        launchJob {
+            combine(
                 getSettingFlow(HiddenKeysSetting),
                 getSettingFlow(KeyBordersSetting),
                 getSettingFlow(KeyHintsSetting)
@@ -516,6 +534,7 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         updateNavigationBarVisibility()
         latinIMELegacy.onConfigurationChanged(newConfig)
         super.onConfigurationChanged(newConfig)
+        uixManager.refreshHardwareToolbarMode()
         uixManager.updateLocaleOnCfgChanged()
     }
 
@@ -609,6 +628,7 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         latinIMELegacy.onStartInput(attribute, restarting)
+        uixManager.refreshHardwareToolbarMode()
         uixManager.inputStarted(attribute)
         //imeManager.onStartInput() // TODO: Is this call needed or not?
     }
@@ -618,6 +638,7 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         onSizeMaybeUpdated()
         imeManager.onStartInput()
         latinIMELegacy.onStartInputView(info, restarting)
+        uixManager.refreshHardwareToolbarMode()
         lifecycleScope.launch { uixManager.showUpdateNoticeIfNeeded() }
         updateColorsIfDynamicChanged()
         uixManager.updateEmojiTranslationsIfNeeded()
@@ -766,7 +787,16 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         return latinIMELegacy.onEvaluateInputViewShown()
                 || super.onEvaluateInputViewShown()
                 || !getSetting(HideKeyboardWhenHardKeyboardConnected)
+                || shouldUseHardwareKeyboardToolbarMode()
     }
+
+    fun hasHardwareKeyboardConnected(): Boolean =
+        Settings.readHasHardwareKeyboard(resources.configuration)
+
+    fun shouldUseHardwareKeyboardToolbarMode(): Boolean =
+        hasHardwareKeyboardConnected()
+                && getSetting(HideKeyboardWhenHardKeyboardConnected)
+                && getSetting(ShowToolbarWhenHardKeyboardConnected)
 
     override fun onEvaluateFullscreenMode(): Boolean {
         // TODO: Revisit fullscreen mode

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -825,6 +825,9 @@ fun ActionBar(
     onQuickClipDismiss: () -> Unit = {},
     needToUseExpandableSuggestionUi: Boolean = false,
     loading: Boolean = false,
+    showTouchKeyboardToggle: Boolean = false,
+    touchKeyboardShown: Boolean = false,
+    onTouchKeyboardToggle: () -> Unit = {},
 ) {
     val view = LocalView.current
     val context = LocalContext.current
@@ -922,6 +925,13 @@ fun ActionBar(
                             Spacer(modifier = Modifier.weight(1.0f))
                         }
 
+                        if(showTouchKeyboardToggle) {
+                            TouchKeyboardToggleButton(
+                                touchKeyboardShown = touchKeyboardShown,
+                                onToggle = onTouchKeyboardToggle
+                            )
+                        }
+
                         if(inlineSuggestions.isEmpty()) {
                             PinnedActionItems(onActionActivated, onActionAltActivated)
                         }
@@ -931,6 +941,33 @@ fun ActionBar(
         }
 
         ActionSep(true)
+    }
+}
+
+@Composable
+private fun TouchKeyboardToggleButton(
+    touchKeyboardShown: Boolean,
+    onToggle: () -> Unit
+) {
+    IconButton(
+        onClick = onToggle,
+        modifier = Modifier
+            .width(42.dp)
+            .fillMaxHeight(),
+        colors = IconButtonDefaults.iconButtonColors(contentColor = LocalKeyboardScheme.current.onBackground)
+    ) {
+        Icon(
+            painter = painterResource(
+                id = if (touchKeyboardShown) R.drawable.arrow_down else R.drawable.keyboard_regular
+            ),
+            contentDescription = stringResource(
+                if (touchKeyboardShown) {
+                    R.string.keyboard_actionbar_hide_touch_keyboard
+                } else {
+                    R.string.keyboard_actionbar_show_touch_keyboard
+                }
+            )
+        )
     }
 }
 

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -887,6 +887,12 @@ fun ActionBar(
                         .fillMaxHeight()) {
                         ActionItems(onActionActivated, onActionAltActivated)
                     }
+                    if(showTouchKeyboardToggle) {
+                        TouchKeyboardToggleButton(
+                            touchKeyboardShown = touchKeyboardShown,
+                            onToggle = onTouchKeyboardToggle
+                        )
+                    }
                 } else {
                     if (importantNotice != null) {
                         ImportantNoticeView(importantNotice)

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -603,6 +603,14 @@ class UixManager(private val latinIME: LatinIME) {
     private val keyboardManagerForAction = UixActionKeyboardManager(this, latinIME)
 
     private var mainKeyboardHidden = mutableStateOf(false)
+    private val hardwareToolbarMode = mutableStateOf(false)
+    private val forceTouchKeyboardForCurrentInput = mutableStateOf(false)
+
+    val isHardwareToolbarModeEffective: Boolean
+        get() = hardwareToolbarMode.value && !forceTouchKeyboardForCurrentInput.value
+
+    private val effectiveMainKeyboardHidden: Boolean
+        get() = mainKeyboardHidden.value || isHardwareToolbarModeEffective
 
     fun getCurrentLayoutName(): String =
         getPrimaryLayoutOverride(latinIME.currentInputEditorInfo)
@@ -646,7 +654,23 @@ class UixManager(private val latinIME: LatinIME) {
     val touchableHeight: Int
         get() = measuredTouchableHeight
 
-    val isMainKeyboardHidden get() = mainKeyboardHidden.value
+    val isMainKeyboardHidden get() = effectiveMainKeyboardHidden
+
+    fun refreshHardwareToolbarMode() {
+        val newValue = latinIME.shouldUseHardwareKeyboardToolbarMode()
+        if (!newValue) {
+            forceTouchKeyboardForCurrentInput.value = false
+        }
+        hardwareToolbarMode.value = newValue
+    }
+
+    fun toggleTouchKeyboardForHardwareToolbarMode() {
+        if (!hardwareToolbarMode.value) return
+        forceTouchKeyboardForCurrentInput.value = !forceTouchKeyboardForCurrentInput.value
+        if (!effectiveMainKeyboardHidden) {
+            latinIME.onKeyboardShown()
+        }
+    }
 
     private fun onActionActivatedInternal(rawAction: Action) {
         resizers.hideResizer()
@@ -688,7 +712,11 @@ class UixManager(private val latinIME: LatinIME) {
 
     @Composable
     private fun MainKeyboardViewWithActionBar(
-        needToUseExpandableSuggestionUi: Boolean
+        needToUseExpandableSuggestionUi: Boolean,
+        forceActionBarShown: Boolean = false,
+        showTouchKeyboardToggle: Boolean = false,
+        touchKeyboardShown: Boolean = false,
+        onTouchKeyboardToggle: () -> Unit = {}
     ) {
         val view = LocalView.current
 
@@ -706,7 +734,7 @@ class UixManager(private val latinIME: LatinIME) {
                 if(!inlineStuffHiddenByTyping.value) inlineSuggestions.value else emptyList()
             }
 
-            if(actionBarShown.value || inlineSuggestions.isNotEmpty()) {
+            if(forceActionBarShown || actionBarShown.value || inlineSuggestions.isNotEmpty()) {
                 ActionBar(
                     suggestedWordsOrNull,
                     suggestionStripListener,
@@ -737,7 +765,10 @@ class UixManager(private val latinIME: LatinIME) {
                     },
                     onQuickClipDismiss = { quickClipState.value = null },
                     needToUseExpandableSuggestionUi = needToUseExpandableSuggestionUi,
-                    loading = latinIME.imeManager.isImeLoading()
+                    loading = latinIME.imeManager.isImeLoading(),
+                    showTouchKeyboardToggle = showTouchKeyboardToggle,
+                    touchKeyboardShown = touchKeyboardShown,
+                    onTouchKeyboardToggle = onTouchKeyboardToggle
                 )
             }
         }
@@ -801,13 +832,14 @@ class UixManager(private val latinIME: LatinIME) {
     @Composable
     private fun ActionViewWithHeader(windowImpl: ActionWindow,
                                      needToUseExpandableSuggestionUi: Boolean) {
-        val heightDiv = if(mainKeyboardHidden.value) {
+        val touchKeyboardHidden = effectiveMainKeyboardHidden
+        val heightDiv = if(touchKeyboardHidden) {
             1
         } else {
             1.5
         }
 
-        val showingAboveKeyboard = !mainKeyboardHidden.value
+        val showingAboveKeyboard = !touchKeyboardHidden
         Column {
             Column(
                 Modifier.background(
@@ -818,7 +850,7 @@ class UixManager(private val latinIME: LatinIME) {
                     }
                 )
             ) {
-                if (mainKeyboardHidden.value || isInputOverridden.value) {
+                if (touchKeyboardHidden || isInputOverridden.value) {
                     ActionWindowBar(
                         onBack = { closeActionWindow(true) },
                         canExpand = currWindowAction.value!!.canShowKeyboard,
@@ -838,11 +870,11 @@ class UixManager(private val latinIME: LatinIME) {
                         })
                         .safeKeyboardPadding()
                 ) {
-                    windowImpl.WindowContents(keyboardShown = !mainKeyboardHidden.value)
+                    windowImpl.WindowContents(keyboardShown = !touchKeyboardHidden)
                 }
             }
 
-            if((!mainKeyboardHidden.value && !latinIME.isInputConnectionOverridden)
+            if((!touchKeyboardHidden && !latinIME.isInputConnectionOverridden)
                 || (latinIME.inputConnectionOverridenWithSuggestions)) {
                 val suggestedWordsOrNull = if (shouldShowSuggestionStrip.value) {
                     suggestedWords.value
@@ -1281,7 +1313,7 @@ class UixManager(private val latinIME: LatinIME) {
                     // TODO: Refactor how we handle expandable suggestions here to not be a mess
                     val needToUseExpandableSuggestionUi =
                         expandableSuggestionCfg.value.useExpandableUi && suggestedWords.value?.size()?.equals(0) != true
-                                && mainKeyboardHidden.value == false
+                                && !effectiveMainKeyboardHidden
                                 && (quickClipState.value == null || inlineStuffHiddenByTyping.value)
                                 && currentNotice.value == null
                                 && (inlineSuggestions.value.isEmpty() || inlineStuffHiddenByTyping.value)
@@ -1292,7 +1324,11 @@ class UixManager(private val latinIME: LatinIME) {
                         )
 
                         else -> MainKeyboardViewWithActionBar(
-                            needToUseExpandableSuggestionUi
+                            needToUseExpandableSuggestionUi,
+                            forceActionBarShown = hardwareToolbarMode.value,
+                            showTouchKeyboardToggle = hardwareToolbarMode.value,
+                            touchKeyboardShown = !isHardwareToolbarModeEffective,
+                            onTouchKeyboardToggle = { toggleTouchKeyboardForHardwareToolbarMode() }
                         )
                     }
 
@@ -1303,7 +1339,9 @@ class UixManager(private val latinIME: LatinIME) {
                     val kbHeight = remember { mutableIntStateOf(latinIME.size.value!!.height) }
                     val keyboardViewOffset = remember(needToUseExpandableSuggestionUi) { mutableIntStateOf(0) }
                     Box(Modifier.let {
-                        if(needToUseExpandableSuggestionUi) {
+                        if(isHardwareToolbarModeEffective) {
+                            it.height(0.dp)
+                        } else if(needToUseExpandableSuggestionUi) {
                             it.height(
                                 with(LocalDensity.current) { kbHeight.intValue.toDp() }
                                         + latinIME.sizingCalculator.calculateSuggestionBarHeightDp().dp
@@ -1338,7 +1376,7 @@ class UixManager(private val latinIME: LatinIME) {
                                 }
                             }
                             .absoluteOffset { IntOffset(0, keyboardViewOffset.intValue) },
-                            hidden = mainKeyboardHidden.value)
+                            hidden = effectiveMainKeyboardHidden)
                     }
 
                     if(latinIME.size.value !is FloatingKeyboardSize) {
@@ -1608,6 +1646,8 @@ class UixManager(private val latinIME: LatinIME) {
     private val quickClipState: MutableState<QuickClipState?> = mutableStateOf(null)
     fun dismissQuickClips() { quickClipState.value = null }
     fun inputStarted(editorInfo: EditorInfo?) {
+        forceTouchKeyboardForCurrentInput.value = false
+        refreshHardwareToolbarMode()
         try {
             checkIfDictInstalled()
         } catch(e: Exception) {
@@ -1632,6 +1672,8 @@ class UixManager(private val latinIME: LatinIME) {
     }
 
     fun onInputFinishing() {
+        forceTouchKeyboardForCurrentInput.value = false
+        refreshHardwareToolbarMode()
         closeActionWindow()
         languageSwitcherDialog?.dismiss()
         isShowingActionEditor.value = false
@@ -1715,5 +1757,4 @@ class UixManager(private val latinIME: LatinIME) {
     val extraTopTouchHeight: Int
         get() = if(floatingPreeditShown) floatingPreeditHeight.value else 0
 }
-
 

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -672,6 +672,18 @@ class UixManager(private val latinIME: LatinIME) {
         }
     }
 
+    private fun expandActionWindowKeyboard() {
+        if (isHardwareToolbarModeEffective) {
+            forceTouchKeyboardForCurrentInput.value = true
+        }
+
+        if (mainKeyboardHidden.value) {
+            toggleExpandAction(false)
+        } else if (!effectiveMainKeyboardHidden) {
+            latinIME.onKeyboardShown()
+        }
+    }
+
     private fun onActionActivatedInternal(rawAction: Action) {
         resizers.hideResizer()
 
@@ -854,7 +866,7 @@ class UixManager(private val latinIME: LatinIME) {
                     ActionWindowBar(
                         onBack = { closeActionWindow(true) },
                         canExpand = currWindowAction.value!!.canShowKeyboard,
-                        onExpand = { toggleExpandAction() },
+                        onExpand = { expandActionWindowKeyboard() },
                         windowTitleBar = { windowImpl.WindowTitleBar(this) }
                     )
                 }
@@ -1757,4 +1769,3 @@ class UixManager(private val latinIME: LatinIME) {
     val extraTopTouchHeight: Int
         get() = if(floatingPreeditShown) floatingPreeditHeight.value else 0
 }
-

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -86,6 +86,7 @@ import org.futo.inputmethod.accessibility.AccessibilityUtils
 import org.futo.inputmethod.engine.IMESettingsMenu
 import org.futo.inputmethod.latin.HideKeyboardWhenHardKeyboardConnected
 import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.ShowToolbarWhenHardKeyboardConnected
 import org.futo.inputmethod.latin.settings.LongPressKey
 import org.futo.inputmethod.latin.settings.LongPressKeyLayoutSetting
 import org.futo.inputmethod.latin.settings.Settings
@@ -848,6 +849,11 @@ val KeyboardSettingsMenu = UserSettingsMenu(
         userSettingToggleDataStore(
             title = R.string.keyboard_settings_hide_when_hardware_keyboard_is_connected,
             setting = HideKeyboardWhenHardKeyboardConnected
+        ),
+        userSettingToggleDataStore(
+            title = R.string.keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected,
+            subtitle = R.string.keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected_subtitle,
+            setting = ShowToolbarWhenHardKeyboardConnected
         )
     )
 )

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -853,7 +853,8 @@ val KeyboardSettingsMenu = UserSettingsMenu(
         userSettingToggleDataStore(
             title = R.string.keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected,
             subtitle = R.string.keyboard_settings_show_toolbar_when_hardware_keyboard_is_connected_subtitle,
-            setting = ShowToolbarWhenHardKeyboardConnected
+            setting = ShowToolbarWhenHardKeyboardConnected,
+            disabled = { !useDataStore(HideKeyboardWhenHardKeyboardConnected).value }
         )
     )
 )


### PR DESCRIPTION
## Summary
- Added a new setting to keep the action/suggestions bar visible when a USB keyboard is connected. (similar to Swiftkey)
- Wired hardware-keyboard detection into `LatinIME` and `UixManager` so the touch keyboard can be hidden while the toolbar remains available.
- Added a toolbar toggle button to show or hide the touch keyboard in hardware keyboard mode.
- Updated the Keyboard & Typing settings page and strings for the new behavior.

<img width="1400" height="920" alt="image" src="https://github.com/user-attachments/assets/b8d76ec1-e93d-4bb2-bd3d-ee6cc1d4bcae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typing setting to keep the toolbar visible when a hardware keyboard is connected.
  * Added a touch-keyboard toggle in the keyboard action bar.
  * Improved hardware-keyboard handling so the keyboard UI and toolbar adapt more consistently when devices are connected or disconnected.

* **Bug Fixes**
  * Updated keyboard visibility and suggestion-bar behavior to better reflect the active hardware-keyboard mode.
  * Refreshed keyboard UI state more reliably when input starts, ends, or device configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->