### PR TITLE
Fix default selection in more-keys popup

### DIFF
--- a/java/src/org/futo/inputmethod/keyboard/MoreKeysKeyboard.java
+++ b/java/src/org/futo/inputmethod/keyboard/MoreKeysKeyboard.java
@@ -35,14 +35,20 @@ import javax.annotation.Nonnull;
 
 public final class MoreKeysKeyboard extends Keyboard {
     private final int mDefaultKeyCoordX;
+    private final Key mDefaultKey;
 
     MoreKeysKeyboard(final MoreKeysKeyboardParams params) {
         super(params);
         mDefaultKeyCoordX = params.getDefaultKeyCoordX() + params.mDefaultKeyWidth / 2;
+        mDefaultKey = params.mDefaultKey;
     }
 
     public int getDefaultCoordX() {
         return mDefaultKeyCoordX;
+    }
+
+    public Key getDefaultKey() {
+        return mDefaultKey;
     }
 
     @UsedForTesting
@@ -56,6 +62,7 @@ public final class MoreKeysKeyboard extends Keyboard {
         public int mRightKeys; // includes default key.
         public int mDividerWidth;
         public int mColumnWidth;
+        public Key mDefaultKey;
 
         public MoreKeysKeyboardParams() {
             super();
@@ -354,6 +361,9 @@ public final class MoreKeysKeyboard extends Keyboard {
                 final int x = params.getX(n, row);
                 final int y = params.getY(row);
                 final Key key = moreKeySpec.buildKey(x, y, moreKeyFlags, params);
+                if (n == 0) {
+                    params.mDefaultKey = key;
+                }
                 params.markAsEdgeKey(key, row);
                 params.onAddKey(key);
             }

--- a/java/src/org/futo/inputmethod/keyboard/MoreKeysKeyboardView.java
+++ b/java/src/org/futo/inputmethod/keyboard/MoreKeysKeyboardView.java
@@ -55,6 +55,7 @@ public class MoreKeysKeyboardView extends KeyboardView implements MoreKeysPanel 
     private Key mCurrentKey;
 
     private int mActivePointerId;
+    private boolean mDefaultKeySelectionFallback;
 
     private final float sideAllowance;
 
@@ -189,7 +190,22 @@ public class MoreKeysKeyboardView extends KeyboardView implements MoreKeysPanel 
     @Override
     public void onDownEvent(final int x, final int y, final int pointerId, final long eventTime) {
         mActivePointerId = pointerId;
+        mDefaultKeySelectionFallback = false;
         mCurrentKey = detectKey(x, y);
+    }
+
+    @Override
+    public void selectDefaultKeyIfNone() {
+        if (mCurrentKey != null) {
+            return;
+        }
+        final Key defaultKey = ((MoreKeysKeyboard)getKeyboard()).getDefaultKey();
+        if (defaultKey == null) {
+            return;
+        }
+        mDefaultKeySelectionFallback = true;
+        mCurrentKey = defaultKey;
+        updatePressKeyGraphics(defaultKey);
     }
 
     @Override
@@ -197,6 +213,10 @@ public class MoreKeysKeyboardView extends KeyboardView implements MoreKeysPanel 
         if (mActivePointerId != pointerId) {
             return;
         }
+        if (mDefaultKeySelectionFallback && mKeyDetector.detectHitKey(x, y) == null) {
+            return;
+        }
+        mDefaultKeySelectionFallback = false;
         final boolean hasOldKey = (mCurrentKey != null);
         mCurrentKey = detectKey(x, y);
         if (hasOldKey && mCurrentKey == null) {
@@ -210,14 +230,18 @@ public class MoreKeysKeyboardView extends KeyboardView implements MoreKeysPanel 
         if (mActivePointerId != pointerId) {
             return;
         }
-        // Calling {@link #detectKey(int,int,int)} here is harmless because the last move event and
-        // the following up event share the same coordinates.
-        mCurrentKey = detectKey(x, y);
+        if (!mDefaultKeySelectionFallback || mKeyDetector.detectHitKey(x, y) != null) {
+            // Calling {@link #detectKey(int,int,int)} here is harmless because the last move event and
+            // the following up event share the same coordinates.
+            mDefaultKeySelectionFallback = false;
+            mCurrentKey = detectKey(x, y);
+        }
         if (mCurrentKey != null) {
             updateReleaseKeyGraphics(mCurrentKey);
             onKeyInput(mCurrentKey, x, y);
             mCurrentKey = null;
         }
+        mDefaultKeySelectionFallback = false;
     }
 
     /**
@@ -281,6 +305,7 @@ public class MoreKeysKeyboardView extends KeyboardView implements MoreKeysPanel 
                 && AccessibilityUtils.getInstance().isAccessibilityEnabled()) {
             accessibilityDelegate.onDismissMoreKeysKeyboard();
         }
+        mDefaultKeySelectionFallback = false;
         mController.onDismissMoreKeysPanel();
     }
 

--- a/java/src/org/futo/inputmethod/keyboard/MoreKeysPanel.java
+++ b/java/src/org/futo/inputmethod/keyboard/MoreKeysPanel.java
@@ -90,6 +90,11 @@ public interface MoreKeysPanel {
     public void onDownEvent(final int x, final int y, final int pointerId, final long eventTime);
 
     /**
+     * Select the default key if no key is currently selected.
+     */
+    public void selectDefaultKeyIfNone();
+
+    /**
      * Process an up event on the more keys panel.
      *
      * @param x translated x coordinate of the touch point

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -1258,6 +1258,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final int translatedX = moreKeysPanel.translateX(mLastX);
         final int translatedY = moreKeysPanel.translateY(mLastY);
         moreKeysPanel.onDownEvent(translatedX, translatedY, mPointerId, SystemClock.uptimeMillis());
+        moreKeysPanel.selectDefaultKeyIfNone();
         mMoreKeysPanel = moreKeysPanel;
     }
 


### PR DESCRIPTION
Fixes #2140 

## Problem

The long-press more-keys popup currently initializes its active key using coordinate-based hit testing based on the last touch position. If the translated touch position misses the popup key area due to touch jitter or event timing, the popup may open without an active (default) selection.

As a result, the default more key (for example, `ś` for Polish `s`) may not be selected immediately, and releasing the finger without moving can fail to commit the expected alternative character.

## Solution

This change preserves the existing coordinate-based selection behavior while adding a fallback mechanism:

* the more-keys keyboard now exposes its default key
* after the synthetic popup `onDownEvent()`, the panel selects the default key if no key is currently selected
* drag-based selection continues to work normally after the popup is opened

## Testing

Manually tested on a physical device:

* Polish layout
* long-press `s`
* verified that `ś` is selected immediately when the popup appears
* verified that releasing without dragging commits `ś`
* repeated the test multiple times; the intermittent missing-selection issue no longer occurred