### PR TITLE
Fix beam search

### DIFF
--- a/native/jni/org_futo_inputmethod_latin_xlm_LanguageModel.cpp
+++ b/native/jni/org_futo_inputmethod_latin_xlm_LanguageModel.cpp
@@ -732,13 +732,13 @@ struct LanguageModelState {
                                index_value[i].first);
                     }
 
-                    if (sequences[i].first > 1.0f || sequences[i].first < 0.0f) {
+                    if (parent_seq.first > 1.0f || parent_seq.first < 0.0f) {
                         AKLOGE("Expected sequences value to be probability [%.2f]",
-                               sequences[i].first);
+                               parent_seq.first);
                     }
 
                     next_sequences.emplace_back(
-                            index_value[i].first * sequences[i].first,
+                            index_value[i].first * parent_seq.first,
                             potential_sequence_data{
                                     new_sequence,
                                     parent_seq.second.seq_id


### PR DESCRIPTION
This fixes ~~a few issues~~ beam search, because I noticed the keyboard performing very poorly. After installing the custom APK my typing experience has improved dramatically.

- MAIN FIX:  beamsearch never worked correctly due to using the wrong parent probability basis, corrected this (this is likely the biggest single improvement) **<--- pick this please even if you disagree with the other tuning**
~~- increased LLM suggestion timeout; this appears to have no negative effect on latency~~
~~- transformer context was too narrow, increased the params and validated empirically~~

I also noticed that the finetuning path was fully disabled in 44c8fcd0c even though USE_TRANSFORMER_FINETUNING is still consumed and I am seeing the tuning setting in the UI. Not touched in this PR but I suggest either completely removing if you think it's not viable on device or re-enabling it since it appears fully viable (and valuable) to me.

I am also trying out training retroactively on my own corpus/on my local workstation from  https://huggingface.co/breadlicker45/futo-keyboard-lm/blob/main/ml4_1_f16_meta_fixed.gguf since apparently no training occurred since ~last October and I have my own idiosyncratic speech patterns that the default model doesn't understand. So far even training on TinyStories gives better/equal performance to the stock model (though it talks about playgrounds and sleepy bears way too much) -- the "explore transformer models" link in the app still leads to an "under construction" page so even replacing that with a brief "how to locally train on your own writing" snippet would help, it trained in under 3 minutes at 2000 steps on a W7800 with no issues and imports fine. 