### PR TITLE
Add optional GIPHY GIF action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,7 +352,7 @@ android {
 
         unstable {
             java.srcDirs = ['common/src', 'java/src', 'java/stable/java']
-            manifest.srcFile 'java/stable/AndroidManifest.xml'
+            manifest.srcFile 'java/unstable/AndroidManifest.xml'
             res.srcDirs = ['java/unstable/res', translationsWithoutEngValues('translations/devbuild')]
         }
 

--- a/java/res/drawable/gif.xml
+++ b/java/res/drawable/gif.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,5L21,5A1,1 0,0 1,22 6L22,18A1,1 0,0 1,21 19L3,19A1,1 0,0 1,2 18L2,6A1,1 0,0 1,3 5z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.5,9.5L6,9.5A1.5,1.5 0,0 0,4.5 11L4.5,13A1.5,1.5 0,0 0,6 14.5L8.5,14.5L8.5,12L7,12"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.5,9.5L11.5,14.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M14.5,14.5L14.5,9.5L18,9.5M14.5,12L17,12"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+</vector>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -44,6 +44,22 @@
     <!-- Must be fairly short -->
     <string name="action_emoji_search_for_emojis">Search</string>
 
+    <!-- For GIF menu action -->
+    <string name="action_gif_title">GIFs</string>
+    <string name="action_gif_search_placeholder">Search GIFs</string>
+    <string name="action_gif_no_results">No GIFs found</string>
+    <string name="action_gif_retry">Retry</string>
+    <string name="action_gif_error_generic">Something went wrong while loading GIFs.</string>
+    <string name="action_gif_download_failed">Could not download this GIF. Check your connection and try again.</string>
+    <string name="action_gif_insert_failed">This app does not support inserting GIFs.</string>
+    <string name="action_gif_no_api_key_title">Set up GIF search</string>
+    <string name="action_gif_no_api_key_subtitle">GIF search uses GIPHY and needs your own API key. Requests are only sent after you add one.</string>
+    <string name="action_gif_save_api_key">Save</string>
+    <string name="giphy_settings_api_key">GIPHY API key</string>
+    <string name="giphy_settings_api_key_subtitle">Required to search and send GIFs.</string>
+    <string name="giphy_settings_api_key_placeholder">Paste your GIPHY API key</string>
+    <string name="giphy_settings_api_key_help">Get a free key from developers.giphy.com. The key is stored only on this device and is sent directly to GIPHY when you search. No requests are made until a key is set.</string>
+
     <!-- For voice input action -->
     <string name="action_voice_input_title">Voice Input</string>
     <!-- Same as the one above but it uses the device's default system voice input instead of the built-in -->
@@ -544,6 +560,7 @@
 
     <string name="swipe_settings_sensitive_swipe">Increase sensitivity</string>
     <string name="swipe_settings_sensitive_swipe_subtitle">Make swipe trigger more often</string>
+
 
     <string name="swipe_settings_kasroz">KASROZ</string>
     <string name="swipe_settings_kasroz_subtitle">The best keyboard layout to swipe</string>

--- a/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
@@ -15,6 +15,7 @@ import org.futo.inputmethod.latin.uix.SettingsKey
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.actions.clipboard.ClipboardHistoryAction
 import org.futo.inputmethod.latin.uix.actions.fonttyper.FontTyperAction
+import org.futo.inputmethod.latin.uix.actions.gif.GifAction
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSettingBlocking
 
@@ -43,6 +44,7 @@ val AllActionsMap = mapOf(
     "left" to ArrowLeftAction,
     "right" to ArrowRightAction,
     "font_typer" to FontTyperAction,
+    "gif" to GifAction,
 )
 
 val ActionToId = AllActionsMap.entries.associate { it.value to it.key }

--- a/java/src/org/futo/inputmethod/latin/uix/actions/gif/GifAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/gif/GifAction.kt
@@ -1,0 +1,367 @@
+package org.futo.inputmethod.latin.uix.actions.gif
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import android.graphics.BitmapFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.common.Constants
+import org.futo.inputmethod.latin.uix.Action
+import org.futo.inputmethod.latin.uix.ActionHeaderSearch
+import org.futo.inputmethod.latin.uix.ActionWindow
+import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
+import org.futo.inputmethod.latin.uix.actions.clipboard.CLIPBOARD_AUTHORITY
+import org.futo.inputmethod.latin.uix.actions.clipboard.ClipboardPasteRequest
+import org.futo.inputmethod.latin.uix.actions.clipboard.ClipboardProviderState
+import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.inputmethod.latin.uix.setSetting
+import org.futo.inputmethod.latin.uix.settings.SettingTextField
+import org.futo.inputmethod.latin.uix.settings.UserSetting
+import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
+import org.futo.inputmethod.latin.uix.settings.userSettingDecorationOnly
+import androidx.core.net.toUri
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+private enum class GifUiState { Loading, Loaded, Empty, Error, NoApiKey }
+
+private suspend fun loadThumbnailBitmap(url: String): ImageBitmap? = withContext(Dispatchers.IO) {
+    var connection: HttpURLConnection? = null
+    try {
+        connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 8000
+            readTimeout = 8000
+        }
+        if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
+        val bytes = connection.inputStream.use { it.readBytes() }
+        decodeSampledBitmap(bytes, 320)
+    } catch (e: Exception) {
+        null
+    } finally {
+        connection?.disconnect()
+    }
+}
+
+private fun decodeSampledBitmap(bytes: ByteArray, maxDim: Int): ImageBitmap? {
+    return try {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        var sampleSize = 1
+        while (bounds.outWidth / sampleSize > maxDim || bounds.outHeight / sampleSize > maxDim) {
+            sampleSize *= 2
+        }
+        val options = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)?.asImageBitmap()
+    } catch (e: Exception) {
+        null
+    }
+}
+
+val GifAction = Action(
+    icon = R.drawable.gif,
+    name = R.string.action_gif_title,
+    canShowKeyboard = true,
+    simplePressImpl = null,
+    windowImpl = { manager, _ ->
+        object : ActionWindow() {
+            private val searchText = mutableStateOf("")
+            private val searching = mutableStateOf(false)
+            private val results = mutableStateOf<List<GiphyGif>>(emptyList())
+            private val uiState = mutableStateOf(GifUiState.Loading)
+            private val errorMessage = mutableStateOf("")
+            private val bannerMessage = mutableStateOf("")
+            private val thumbnails = mutableStateMapOf<String, ImageBitmap>()
+            private var loadJob: Job? = null
+
+            @Composable
+            override fun windowName(): String = stringResource(R.string.action_gif_title)
+
+            private fun load(query: String) {
+                val context = manager.getContext()
+                val apiKey = context.getSetting(GiphyApiKeySetting)
+                if (apiKey.isBlank()) {
+                    uiState.value = GifUiState.NoApiKey
+                    return
+                }
+                bannerMessage.value = ""
+                uiState.value = GifUiState.Loading
+                loadJob?.cancel()
+                loadJob = manager.getLifecycleScope().launch {
+                    GiphyApi.cleanupCache(context)
+                    val result = if (query.isBlank()) {
+                        GiphyApi.trending(apiKey)
+                    } else {
+                        GiphyApi.search(apiKey, query)
+                    }
+                    result.onSuccess { list ->
+                        results.value = list
+                        uiState.value = if (list.isEmpty()) GifUiState.Empty else GifUiState.Loaded
+                    }.onFailure { e ->
+                        errorMessage.value = e.message ?: context.getString(R.string.action_gif_error_generic)
+                        uiState.value = GifUiState.Error
+                    }
+                }
+            }
+
+            private fun insert(gif: GiphyGif) {
+                val context = manager.getContext()
+                val url = gif.insertionUrl()
+                if (url.isEmpty()) return
+                manager.getLifecycleScope().launch {
+                    val file = GiphyApi.downloadToCache(context, url, gif.id)
+                    if (file == null) {
+                        bannerMessage.value = context.getString(R.string.action_gif_download_failed)
+                        return@launch
+                    }
+                    val request = ClipboardProviderState.addRequest(
+                        ClipboardPasteRequest(
+                            file = file,
+                            mimeType = GIF_MIME_TYPE,
+                            expiration = System.currentTimeMillis() + 5L * 60L * 1000L
+                        )
+                    )
+                    val uri = "content://${CLIPBOARD_AUTHORITY}/clip/$request".toUri()
+                    if (!manager.typeUri(uri, listOf(GIF_MIME_TYPE), true)) {
+                        bannerMessage.value = context.getString(R.string.action_gif_insert_failed)
+                    }
+                }
+            }
+
+            @Composable
+            override fun WindowContents(keyboardShown: Boolean) {
+                val view = LocalView.current
+                LaunchedEffect(Unit) {
+                    if (uiState.value == GifUiState.Loading && results.value.isEmpty()) {
+                        load(searchText.value)
+                    }
+                }
+
+                Column(Modifier.fillMaxSize()) {
+                    val banner = bannerMessage.value
+                    if (banner.isNotEmpty()) {
+                        Text(
+                            banner,
+                            modifier = Modifier.fillMaxWidth().padding(8.dp),
+                            textAlign = TextAlign.Center,
+                            color = LocalKeyboardScheme.current.error
+                        )
+                    }
+
+                    when (uiState.value) {
+                        GifUiState.NoApiKey -> NoApiKeyContent(onSaved = { load(searchText.value) })
+                        GifUiState.Loading -> CenteredMessage { CircularProgressIndicator(Modifier.size(48.dp)) }
+                        GifUiState.Error -> CenteredMessage {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(errorMessage.value, textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(8.dp))
+                                TextButton(onClick = { load(searchText.value) }) {
+                                    Text(stringResource(R.string.action_gif_retry))
+                                }
+                            }
+                        }
+                        GifUiState.Empty -> CenteredMessage {
+                            Text(stringResource(R.string.action_gif_no_results), textAlign = TextAlign.Center)
+                        }
+                        GifUiState.Loaded -> GifGrid(
+                            gifs = results.value,
+                            thumbnails = thumbnails,
+                            onClick = { gif ->
+                                insert(gif)
+                                manager.performHapticAndAudioFeedback(Constants.CODE_OUTPUT_TEXT, view)
+                            }
+                        )
+                    }
+                }
+            }
+
+            @Composable
+            private fun NoApiKeyContent(onSaved: () -> Unit) {
+                val context = LocalContext.current
+                val keyText = remember { mutableStateOf("") }
+                Column(
+                    modifier = Modifier.fillMaxSize().padding(16.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(stringResource(R.string.action_gif_no_api_key_title),
+                        textAlign = TextAlign.Center)
+                    Spacer(Modifier.height(8.dp))
+                    Text(stringResource(R.string.action_gif_no_api_key_subtitle),
+                        textAlign = TextAlign.Center)
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = keyText.value,
+                        onValueChange = { keyText.value = it },
+                        placeholder = { Text(stringResource(R.string.giphy_settings_api_key_placeholder)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Button(onClick = {
+                        manager.getLifecycleScope().launch {
+                            context.setSetting(GiphyApiKeySetting, keyText.value.trim())
+                            onSaved()
+                        }
+                    }) {
+                        Text(stringResource(R.string.action_gif_save_api_key))
+                    }
+                }
+            }
+
+            @Composable
+            private fun CenteredMessage(content: @Composable () -> Unit) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }
+            }
+
+            @Composable
+            private fun GifGrid(
+                gifs: List<GiphyGif>,
+                thumbnails: androidx.compose.runtime.snapshots.SnapshotStateMap<String, ImageBitmap>,
+                onClick: (GiphyGif) -> Unit
+            ) {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(120.dp),
+                    modifier = Modifier.fillMaxSize().padding(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(gifs, key = { it.id }) { gif ->
+                        GifCell(gif, thumbnails, onClick)
+                    }
+                }
+            }
+
+            @Composable
+            private fun GifCell(
+                gif: GiphyGif,
+                thumbnails: androidx.compose.runtime.snapshots.SnapshotStateMap<String, ImageBitmap>,
+                onClick: (GiphyGif) -> Unit
+            ) {
+                val url = gif.thumbnailUrl()
+                LaunchedEffect(url) {
+                    if (url.isNotEmpty() && !thumbnails.containsKey(url)) {
+                        val bitmap = loadThumbnailBitmap(url)
+                        if (bitmap != null) thumbnails[url] = bitmap
+                    }
+                }
+                val bitmap = thumbnails[url]
+                Box(
+                    modifier = Modifier
+                        .height(100.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(LocalKeyboardScheme.current.keyboardContainer)
+                        .clickable { onClick(gif) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (bitmap != null) {
+                        Image(
+                            bitmap = bitmap,
+                            contentDescription = gif.title,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        CircularProgressIndicator(Modifier.size(24.dp))
+                    }
+                }
+            }
+
+            @Composable
+            override fun WindowTitleBar(rowScope: RowScope) {
+                if (searching.value) {
+                    with(rowScope) {
+                        ActionHeaderSearch(searchText, Modifier.weight(1.0f),
+                            stringResource(R.string.action_gif_search_placeholder))
+                        IconButton(onClick = { load(searchText.value) }) {
+                            Icon(Icons.Default.Search, contentDescription = stringResource(R.string.action_gif_search_placeholder))
+                        }
+                        IconButton(onClick = {
+                            searching.value = false
+                            searchText.value = ""
+                            load("")
+                        }) {
+                            Icon(Icons.Default.Close, contentDescription = null)
+                        }
+                    }
+                } else {
+                    super.WindowTitleBar(rowScope)
+                    IconButton(onClick = { searching.value = true }) {
+                        Icon(Icons.Default.Search, contentDescription = stringResource(R.string.action_gif_search_placeholder))
+                    }
+                }
+            }
+        }
+    },
+    settingsMenu = UserSettingsMenu(
+        title = R.string.action_gif_title,
+        navPath = "actions/gif",
+        registerNavPath = true,
+        settings = listOf(
+            UserSetting(
+                name = R.string.giphy_settings_api_key,
+                subtitle = R.string.giphy_settings_api_key_subtitle,
+                component = {
+                    SettingTextField(
+                        title = stringResource(R.string.giphy_settings_api_key),
+                        placeholder = stringResource(R.string.giphy_settings_api_key_placeholder),
+                        field = GiphyApiKeySetting
+                    )
+                }
+            ),
+            userSettingDecorationOnly {
+                Text(
+                    stringResource(R.string.giphy_settings_api_key_help),
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        )
+    )
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/gif/GiphyApi.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/gif/GiphyApi.kt
@@ -1,0 +1,147 @@
+package org.futo.inputmethod.latin.uix.actions.gif
+
+import android.content.Context
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.futo.inputmethod.latin.uix.SettingsKey
+import java.io.File
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+val GiphyApiKeySetting = SettingsKey(
+    key = stringPreferencesKey("giphy_api_key"),
+    default = ""
+)
+
+const val GIF_MIME_TYPE = "image/gif"
+
+@Serializable
+data class GiphyImage(
+    val url: String = "",
+    val width: String = "0",
+    val height: String = "0",
+    val size: String = "0"
+)
+
+@Serializable
+data class GiphyImages(
+    @SerialName("fixed_width") val fixedWidth: GiphyImage? = null,
+    @SerialName("fixed_width_still") val fixedWidthStill: GiphyImage? = null,
+    @SerialName("fixed_width_downsampled") val fixedWidthDownsampled: GiphyImage? = null,
+    @SerialName("downsized") val downsized: GiphyImage? = null
+)
+
+@Serializable
+data class GiphyGif(
+    val id: String = "",
+    val title: String? = null,
+    val images: GiphyImages = GiphyImages()
+) {
+    fun thumbnailUrl(): String =
+        images.fixedWidthStill?.url
+            ?: images.fixedWidthDownsampled?.url
+            ?: images.fixedWidth?.url
+            ?: ""
+
+    fun insertionUrl(): String =
+        images.fixedWidth?.url
+            ?: images.downsized?.url
+            ?: images.fixedWidthStill?.url
+            ?: ""
+}
+
+@Serializable
+data class GiphyResponse(
+    val data: List<GiphyGif> = emptyList()
+)
+
+object GiphyApi {
+    private const val BASE_URL = "https://api.giphy.com/v1/gifs"
+    private const val LIMIT = 24
+    private const val RATING = "g"
+    private const val TIMEOUT_MS = 8000
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun trending(apiKey: String): Result<List<GiphyGif>> =
+        get("$BASE_URL/trending?api_key=${encode(apiKey)}&limit=$LIMIT&rating=$RATING")
+
+    suspend fun search(apiKey: String, query: String): Result<List<GiphyGif>> =
+        get("$BASE_URL/search?api_key=${encode(apiKey)}&q=${encode(query)}&limit=$LIMIT&rating=$RATING")
+
+    private suspend fun get(url: String): Result<List<GiphyGif>> = withContext(Dispatchers.IO) {
+        var connection: HttpURLConnection? = null
+        try {
+            connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                requestMethod = "GET"
+                setRequestProperty("Accept", "application/json")
+            }
+            val code = connection.responseCode
+            if (code != HttpURLConnection.HTTP_OK) {
+                return@withContext Result.failure(IOException("GIPHY returned HTTP $code"))
+            }
+            val body = connection.inputStream.bufferedReader().use { it.readText() }
+            Result.success(json.decodeFromString<GiphyResponse>(body).data)
+        } catch (e: Exception) {
+            Result.failure(e)
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    suspend fun downloadToCache(context: Context, url: String, id: String): File? =
+        withContext(Dispatchers.IO) {
+            var connection: HttpURLConnection? = null
+            var tempFile: File? = null
+            try {
+                connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                    connectTimeout = TIMEOUT_MS
+                    readTimeout = TIMEOUT_MS
+                    requestMethod = "GET"
+                }
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                    return@withContext null
+                }
+                val dir = File(context.cacheDir, "gifs").apply { mkdirs() }
+                tempFile = File(dir, "$id.gif.part")
+                connection.inputStream.use { input ->
+                    tempFile.outputStream().use { out -> input.copyTo(out) }
+                }
+                val finalFile = File(dir, "$id.gif")
+                if (finalFile.exists()) finalFile.delete()
+                if (tempFile.renameTo(finalFile)) finalFile else {
+                    tempFile.delete()
+                    null
+                }
+            } catch (e: Exception) {
+                tempFile?.delete()
+                null
+            } finally {
+                connection?.disconnect()
+            }
+        }
+
+    suspend fun cleanupCache(context: Context) = withContext(Dispatchers.IO) {
+        try {
+            val dir = File(context.cacheDir, "gifs")
+            val files = dir.listFiles() ?: return@withContext
+            val cutoff = System.currentTimeMillis() - 60L * 60L * 1000L
+            for (file in files) {
+                if (file.name.endsWith(".part") || file.lastModified() < cutoff) {
+                    file.delete()
+                }
+            }
+        } catch (e: Exception) {
+        }
+    }
+
+    private fun encode(value: String): String = URLEncoder.encode(value, "UTF-8")
+}

--- a/java/unstable/AndroidManifest.xml
+++ b/java/unstable/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- GIF search (GIPHY) is an opt-in, network-backed feature. It is only enabled on
+         unstable builds so that stable and playstore releases stay fully offline. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <service
+            android:name="org.futo.inputmethod.updates.UpdateCheckingService"
+            android:label="@string/autoupdater_service_title"
+            android:permission="android.permission.BIND_JOB_SERVICE" >
+        </service>
+
+        <receiver android:name="org.futo.inputmethod.updates.InstallReceiver" />
+
+    </application>
+</manifest>

--- a/src/test/java/org/futo/inputmethod/latin/uix/actions/gif/GiphyGifTest.java
+++ b/src/test/java/org/futo/inputmethod/latin/uix/actions/gif/GiphyGifTest.java
@@ -1,0 +1,66 @@
+package org.futo.inputmethod.latin.uix.actions.gif;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class GiphyGifTest {
+
+    private static GiphyImage img(String url) {
+        return new GiphyImage(url, "200", "200", "1000");
+    }
+
+    @Test
+    public void thumbnailPrefersStillOverDownsampled() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                img("fw.gif"), img("still.gif"), img("down.gif"), img("dz.gif")));
+        assertEquals("still.gif", gif.thumbnailUrl());
+    }
+
+    @Test
+    public void thumbnailFallsBackToDownsampled() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                img("fw.gif"), null, img("down.gif"), null));
+        assertEquals("down.gif", gif.thumbnailUrl());
+    }
+
+    @Test
+    public void thumbnailFallsBackToFixedWidth() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                img("fw.gif"), null, null, null));
+        assertEquals("fw.gif", gif.thumbnailUrl());
+    }
+
+    @Test
+    public void thumbnailEmptyWhenNoImages() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(null, null, null, null));
+        assertEquals("", gif.thumbnailUrl());
+    }
+
+    @Test
+    public void insertionPrefersFixedWidth() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                img("fw.gif"), img("still.gif"), null, img("dz.gif")));
+        assertEquals("fw.gif", gif.insertionUrl());
+    }
+
+    @Test
+    public void insertionFallsBackToDownsized() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                null, img("still.gif"), null, img("dz.gif")));
+        assertEquals("dz.gif", gif.insertionUrl());
+    }
+
+    @Test
+    public void insertionFallsBackToStill() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(
+                null, img("still.gif"), null, null));
+        assertEquals("still.gif", gif.insertionUrl());
+    }
+
+    @Test
+    public void insertionEmptyWhenNoImages() {
+        GiphyGif gif = new GiphyGif("1", "t", new GiphyImages(null, null, null, null));
+        assertEquals("", gif.insertionUrl());
+    }
+}


### PR DESCRIPTION
## Summary
- add a GIF action that users can place through the Action Editor
- provide trending/search results through GIPHY only after the user supplies their own API key
- cache GIF downloads and insert them using the IME image-content URI path
- expose download and unsupported-editor failures in the action UI

## Privacy and scope
- no API key is included in this change
- the action is limited to the unstable flavor, where it declares the required network permission

## Tests
- `./gradlew testUnstableDebugUnitTest compileUnstableDebugSources --console=plain`

This is intentionally separate from the swipe-delete PR because it introduces an external online service.