### PR TITLE
Add configurable flick gesture sensitivity setting

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -425,6 +425,10 @@
     <string name="morekey_settings_show_hints_tags">additional characters, alt keys, symbols, popup keys</string>
     <string name="morekey_settings_duration">Long Press Duration</string>
     <string name="morekey_settings_duration_subtitle">How long a key needs to be pressed to be considered a long-press</string>
+    <string name="morekey_settings_flick_threshold">Flick sensitivity</string>
+    <string name="morekey_settings_flick_threshold_subtitle">Adjust how far you need to swipe to trigger a flick action. Lower values make flick easier to trigger.</string>
+    <string name="morekey_settings_flick_threshold_default">Default</string>
+    <string name="morekey_settings_flick_threshold_tags">flick, swipe, gesture, sensitivity, threshold, distance</string>
 
     <string name="morekey_settings_backspace_title">Backspace</string>
     <string name="morekey_settings_backspace_hold_delete_words">Hold to delete words</string>

--- a/java/src/org/futo/inputmethod/keyboard/Key.kt
+++ b/java/src/org/futo/inputmethod/keyboard/Key.kt
@@ -554,7 +554,7 @@ data class Key(
             val dirs = computeDirectionsFromDeltaPos(
                 dx = dx.toDouble(),
                 dy = dy.toDouble(),
-                threshold = (width / 3).toDouble()
+                threshold = (width * flickThresholdRatio).toDouble()
             )
             dirs.firstOrNull { flickKeys.contains(it) }
         }
@@ -569,6 +569,10 @@ data class Key(
         get() = mFlickDirection
 
     companion object {
+        @Volatile
+        @JvmStatic
+        var flickThresholdRatio: Float = 1.0f / 3.0f
+
         @JvmStatic
         fun removeRedundantMoreKeys(
             key: Key,

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -59,6 +59,7 @@ import org.futo.inputmethod.accessibility.AccessibilityUtils
 import org.futo.inputmethod.engine.ExpandableSuggestionBarConfiguration
 import org.futo.inputmethod.engine.IMEManager
 import org.futo.inputmethod.engine.general.WordLearner
+import org.futo.inputmethod.keyboard.Key
 import org.futo.inputmethod.latin.SuggestedWords.SuggestedWordInfo
 import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.settings.Settings
@@ -86,6 +87,8 @@ import org.futo.inputmethod.latin.uix.getSettingFlow
 import org.futo.inputmethod.latin.uix.isDirectBootUnlocked
 import org.futo.inputmethod.latin.uix.safeKeyboardPadding
 import org.futo.inputmethod.latin.uix.setSetting
+import org.futo.inputmethod.latin.uix.settings.pages.FLICK_THRESHOLD_DEFAULT
+import org.futo.inputmethod.latin.uix.settings.pages.flickThresholdSetting
 import org.futo.inputmethod.latin.uix.theme.ThemeOption
 import org.futo.inputmethod.latin.uix.theme.applyWindowColors
 import org.futo.inputmethod.latin.uix.theme.getThemeOption
@@ -438,6 +441,16 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
                         }
                     }
                 }
+        }
+
+        val toFlickThresholdRatio: (Int) -> Float = {
+            if(it < 0) FLICK_THRESHOLD_DEFAULT else it / 100.0f
+        }
+        Key.flickThresholdRatio = toFlickThresholdRatio(getSettingBlocking(flickThresholdSetting))
+        launchJob {
+            getSettingFlow(flickThresholdSetting).collect {
+                Key.flickThresholdRatio = toFlickThresholdRatio(it)
+            }
         }
 
         launchJob {

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -145,6 +145,15 @@ val keySoundVolumeSetting = SettingsKey(
     0.0f
 )
 
+// Percentage of the key width a swipe has to cover to trigger a flick.
+// -1 means "use the built-in default", see FLICK_THRESHOLD_DEFAULT.
+val flickThresholdSetting = SettingsKey(
+    intPreferencesKey("flick_threshold_percent"),
+    -1
+)
+
+const val FLICK_THRESHOLD_DEFAULT = 1.0f / 3.0f
+
 val ActionBarDisplayedSetting = SettingsKey(
     booleanPreferencesKey("enable_action_bar"),
     true
@@ -661,6 +670,29 @@ val LongPressMenu = UserSettingsMenu(
                 transform = { it.roundToInt() },
                 indicator = { resources.getString(R.string.abbreviation_unit_milliseconds, "$it") },
                 steps = 23
+            )
+        },
+
+        UserSetting(
+            name = R.string.morekey_settings_flick_threshold,
+            subtitle = R.string.morekey_settings_flick_threshold_subtitle,
+            searchTags = R.string.morekey_settings_flick_threshold_tags,
+        ) {
+            val resources = LocalResources.current
+            SettingSlider(
+                title = stringResource(R.string.morekey_settings_flick_threshold),
+                subtitle = stringResource(R.string.morekey_settings_flick_threshold_subtitle),
+                setting = flickThresholdSetting,
+                range = -1.0f .. 100.0f,
+                hardRange = -1.0f .. 100.0f,
+                transform = { if(it < 1.0f) -1 else it.roundToInt() },
+                indicator = {
+                    if(it < 0) {
+                        resources.getString(R.string.morekey_settings_flick_threshold_default)
+                    } else {
+                        "$it%"
+                    }
+                }
             )
         },
     )


### PR DESCRIPTION
## Summary

The flick gesture threshold is currently hardcoded to one third of the key width in `Key.flickDirection`. On flick layouts with small keys, or for users who prefer shorter gestures, that distance is farther than comfortable, and there is no way to adjust it.

This adds a "Flick sensitivity" slider so the threshold can be tuned, while keeping the current behavior as the default.

## Changes

- Add a "Flick sensitivity" slider to the "Long-Press Keys & Spacebar" settings menu, placed next to the existing "Long Press Duration" slider.
- Store the threshold as an integer percentage of the key width, adjustable from 1% to 100%, with `-1` selecting the built-in default of one third.
- Replace the hardcoded `width / 3` threshold in `Key` with a configurable `Key.flickThresholdRatio` companion property.
- Read the initial value and observe subsequent changes in `LatinIME`.

The slider follows the existing "Vibration" setting: the stored unit matches the slider range, values are quantized on write so the indicator always matches what is stored, and the `-1` sentinel renders as "Default".

## Notes

- Default behavior is unchanged — the threshold stays at one third of the key width unless the user moves the slider.
- Only affects layouts that use flick keys (the Japanese 12-key layouts, and custom flick layouts).