### PR TITLE
Recapitalize word at cursor with Shift

### DIFF
--- a/common/src/org/futo/inputmethod/latin/common/StringUtils.java
+++ b/common/src/org/futo/inputmethod/latin/common/StringUtils.java
@@ -405,6 +405,49 @@ public final class StringUtils {
         return true;
     }
 
+    /**
+     * Finds the word at or immediately before the cursor.
+     *
+     * The word is the maximal run of code points which are not in sortedWordSeparators that
+     * contains the cursor, starts right at the cursor, or ends right at the cursor.
+     *
+     * @param textBeforeCursor the text ending right at the cursor position.
+     * @param textAfterCursor the text starting right at the cursor position.
+     * @param sortedWordSeparators a sorted array of word separator code points.
+     * @return int[]{index where the word starts in textBeforeCursor,
+     *         index just past where the word ends in textAfterCursor}, or null if the cursor
+     *         is not adjacent to a word.
+     */
+    @Nullable
+    public static int[] getWordRangeAtCursor(@Nullable final CharSequence textBeforeCursor,
+            @Nullable final CharSequence textAfterCursor,
+            @Nonnull final int[] sortedWordSeparators) {
+        final int beforeLength = null == textBeforeCursor ? 0 : textBeforeCursor.length();
+        int start = beforeLength;
+        while (start > 0) {
+            final int codePoint = Character.codePointBefore(textBeforeCursor, start);
+            if (Arrays.binarySearch(sortedWordSeparators, codePoint) >= 0) {
+                break;
+            }
+            start -= Character.charCount(codePoint);
+        }
+        int end = 0;
+        if (null != textAfterCursor) {
+            final int afterLength = textAfterCursor.length();
+            while (end < afterLength) {
+                final int codePoint = Character.codePointAt(textAfterCursor, end);
+                if (Arrays.binarySearch(sortedWordSeparators, codePoint) >= 0) {
+                    break;
+                }
+                end += Character.charCount(codePoint);
+            }
+        }
+        if (start == beforeLength && end == 0) {
+            return null; // The cursor is not adjacent to a word on either side.
+        }
+        return new int[] { start, end };
+    }
+
     // TODO: like capitalizeFirst*, this does not work perfectly for Dutch because of the IJ digraph
     // which should be capitalized together in *some* cases.
     @Nonnull

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -1971,12 +1971,11 @@ public final class InputLogic {
      * @param settingsValues The current settings values.
      */
     private void performRecapitalization(final SettingsValues settingsValues) {
-        if (!mRecapitalizeStatus.mIsEnabled()) return;
-
         int selectionStart = mConnection.getExpectedSelectionStart();
         int selectionEnd = mConnection.getExpectedSelectionEnd();
         CharSequence textToRecapitalize;
         if (mConnection.hasSelection()) {
+            if (!mRecapitalizeStatus.mIsEnabled()) return;
             textToRecapitalize = mConnection.getSelectedText(0 /* flags, 0 for no styles */);
         } else {
             if (!mConnection.isCursorPositionKnown()) return;
@@ -1997,6 +1996,10 @@ public final class InputLogic {
                     && textAfterCursor.length() == Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION)) {
                 return;
             }
+            // Existing recapitalization waits for a cursor-move callback after starting input.
+            // Cursor-only recapitalization has independently validated the current cursor and
+            // surrounding text, so it is safe to enable without requiring that extra movement.
+            mRecapitalizeStatus.enable();
             selectionStart -= textBeforeCursor.length() - wordRange[0];
             selectionEnd += wordRange[1];
             textToRecapitalize = textBeforeCursor.subSequence(wordRange[0],

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -1208,6 +1208,17 @@ public final class InputLogic {
         final int codePoint = event.mCodePoint;
         final SettingsValues settingsValues = inputTransaction.mSettingsValues;
         final boolean wasComposingWord = mWordComposer.isComposingWord();
+        // A recapitalized word is kept selected so that Shift can cycle its case. If a
+        // separator is typed while that selection is active, commit the word first by
+        // collapsing the selection to its end, otherwise the separator would replace the
+        // selection and delete the word.
+        if (mRecapitalizeStatus.isStarted()
+                && mRecapitalizeStatus.isSetAt(mConnection.getExpectedSelectionStart(),
+                        mConnection.getExpectedSelectionEnd())) {
+            mConnection.setSelection(mRecapitalizeStatus.getNewCursorEnd(),
+                    mRecapitalizeStatus.getNewCursorEnd());
+            mRecapitalizeStatus.stop();
+        }
         // We avoid sending spaces in languages without spaces if we were composing.
         final boolean shouldAvoidSendingCode = Constants.CODE_SPACE == codePoint
                 && !settingsValues.mSpacingAndPunctuations.currentLanguageHasSpaces

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -1971,11 +1971,40 @@ public final class InputLogic {
      * @param settingsValues The current settings values.
      */
     private void performRecapitalization(final SettingsValues settingsValues) {
-        if (!mConnection.hasSelection() || !mRecapitalizeStatus.mIsEnabled()) {
-            return; // No selection or recapitalize is disabled for now
+        if (!mRecapitalizeStatus.mIsEnabled()) return;
+
+        int selectionStart = mConnection.getExpectedSelectionStart();
+        int selectionEnd = mConnection.getExpectedSelectionEnd();
+        CharSequence textToRecapitalize;
+        if (mConnection.hasSelection()) {
+            textToRecapitalize = mConnection.getSelectedText(0 /* flags, 0 for no styles */);
+        } else {
+            if (!mConnection.isCursorPositionKnown()) return;
+            final CharSequence textBeforeCursor = mConnection.getTextBeforeCursor(
+                    Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION, 0 /* flags */);
+            final CharSequence textAfterCursor = mConnection.getTextAfterCursor(
+                    Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION, 0 /* flags */);
+            if (textBeforeCursor == null || textAfterCursor == null) return;
+            final int[] wordRange = StringUtils.getWordRangeAtCursor(textBeforeCursor,
+                    textAfterCursor,
+                    settingsValues.mSpacingAndPunctuations.sortedWordSeparators);
+            if (wordRange == null) return;
+            // A full buffer ending inside a word may have omitted part of that word. Refuse to
+            // recapitalize a partial word rather than silently changing only a suffix or prefix.
+            if ((wordRange[0] == 0
+                    && textBeforeCursor.length() == Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION)
+                    || (wordRange[1] == textAfterCursor.length()
+                    && textAfterCursor.length() == Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION)) {
+                return;
+            }
+            selectionStart -= textBeforeCursor.length() - wordRange[0];
+            selectionEnd += wordRange[1];
+            textToRecapitalize = textBeforeCursor.subSequence(wordRange[0],
+                    textBeforeCursor.length()).toString()
+                    + textAfterCursor.subSequence(0, wordRange[1]);
         }
-        final int selectionStart = mConnection.getExpectedSelectionStart();
-        final int selectionEnd = mConnection.getExpectedSelectionEnd();
+        if (TextUtils.isEmpty(textToRecapitalize)) return; // Race condition with the input connection
+
         final int numCharsSelected = selectionEnd - selectionStart;
         if (numCharsSelected > Constants.MAX_CHARACTERS_FOR_RECAPITALIZATION) {
             // We bail out if we have too many characters for performance reasons. We don't want
@@ -1985,10 +2014,7 @@ public final class InputLogic {
         // If we have a recapitalize in progress, use it; otherwise, start a new one.
         if (!mRecapitalizeStatus.isStarted()
                 || !mRecapitalizeStatus.isSetAt(selectionStart, selectionEnd)) {
-            final CharSequence selectedText =
-                    mConnection.getSelectedText(0 /* flags, 0 for no styles */);
-            if (TextUtils.isEmpty(selectedText)) return; // Race condition with the input connection
-            mRecapitalizeStatus.start(selectionStart, selectionEnd, selectedText.toString(),
+            mRecapitalizeStatus.start(selectionStart, selectionEnd, textToRecapitalize.toString(),
                     settingsValues.mLocale,
                     settingsValues.mSpacingAndPunctuations.sortedWordSeparators);
             // We trim leading and trailing whitespace.

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -2031,6 +2031,7 @@ public final class InputLogic {
         mConnection.send();
         mConnection.setSelection(mRecapitalizeStatus.getNewCursorStart(),
                 mRecapitalizeStatus.getNewCursorEnd());
+        resetComposingState(true /* alsoResetLastComposedWord */);
     }
 
     private void performAdditionToUserHistoryDictionary(final SettingsValues settingsValues,

--- a/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
+++ b/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
@@ -216,6 +216,19 @@ public class InputLogicTests extends InputTestsBase {
                 mEditText.getText().toString());
     }
 
+    public void testRecapitalizeThenSpaceDoesNotAutoCorrect() {
+        final String WORD_TO_TYPE = "tgis";
+        final String EXPECTED_AFTER_RECAP = "Tgis";
+        final String EXPECTED_RESULT = "Tgis ";
+        type(WORD_TO_TYPE);
+        type(Constants.CODE_SHIFT);
+        assertEquals("shift should recapitalize the word at the cursor",
+                EXPECTED_AFTER_RECAP, mEditText.getText().toString());
+        type(Constants.CODE_SPACE);
+        assertEquals("space should commit the recapitalized word, not a stale auto-correction",
+                EXPECTED_RESULT, mEditText.getText().toString());
+    }
+
     public void testDoubleSpace() {
         // U+1F607 is an emoji
         final String[] STRINGS_TO_TYPE =

--- a/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
+++ b/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
@@ -229,6 +229,31 @@ public class InputLogicTests extends InputTestsBase {
                 EXPECTED_RESULT, mEditText.getText().toString());
     }
 
+    public void testRecapitalizeShiftCyclingThenSpace() {
+        final String WORD_TO_TYPE = "tgis";
+        type(WORD_TO_TYPE);
+        type(Constants.CODE_SHIFT);
+        assertEquals("first shift should recapitalize the word at the cursor",
+                "Tgis", mEditText.getText().toString());
+        type(Constants.CODE_SHIFT);
+        assertEquals("second shift should cycle the case of the selected recapitalized word",
+                "TGIS", mEditText.getText().toString());
+        type(Constants.CODE_SPACE);
+        assertEquals("space should commit the cycled recapitalized word",
+                "TGIS ", mEditText.getText().toString());
+    }
+
+    public void testRecapitalizeThenPunctuation() {
+        final String WORD_TO_TYPE = "tgis";
+        type(WORD_TO_TYPE);
+        type(Constants.CODE_SHIFT);
+        assertEquals("shift should recapitalize the word at the cursor",
+                "Tgis", mEditText.getText().toString());
+        type(Constants.CODE_PERIOD);
+        assertEquals("punctuation should commit the recapitalized word",
+                "Tgis.", mEditText.getText().toString());
+    }
+
     public void testDoubleSpace() {
         // U+1F607 is an emoji
         final String[] STRINGS_TO_TYPE =

--- a/tests/src/org/futo/inputmethod/latin/common/StringUtilsTests.java
+++ b/tests/src/org/futo/inputmethod/latin/common/StringUtilsTests.java
@@ -35,11 +35,13 @@ public class StringUtilsTests {
     private static final Locale GERMAN = Locale.GERMAN;
     private static final Locale TURKEY = new Locale("tr", "TR");
     private static final Locale GREECE = new Locale("el", "GR");
-    private static final int[] WORD_SEPARATORS = StringUtils.toSortedCodePointArray(" .,!");
+    private static final int[] RECAPITALIZE_WORD_SEPARATORS =
+            StringUtils.toSortedCodePointArray(" .,!");
 
     private static void assertWordRange(final String before, final String after,
             final int expectedStart, final int expectedEnd) {
-        final int[] range = StringUtils.getWordRangeAtCursor(before, after, WORD_SEPARATORS);
+        final int[] range = StringUtils.getWordRangeAtCursor(before, after,
+                RECAPITALIZE_WORD_SEPARATORS);
         assertEquals(expectedStart, range[0]);
         assertEquals(expectedEnd, range[1]);
     }
@@ -52,8 +54,9 @@ public class StringUtilsTests {
         assertWordRange("", "café!", 0, 4);
         assertWordRange("go😀", "!", 0, 0);
         assertEquals(null, StringUtils.getWordRangeAtCursor("hello ", ". world",
-                WORD_SEPARATORS));
-        assertEquals(null, StringUtils.getWordRangeAtCursor("hello ", "", WORD_SEPARATORS));
+                RECAPITALIZE_WORD_SEPARATORS));
+        assertEquals(null, StringUtils.getWordRangeAtCursor("hello ", "",
+                RECAPITALIZE_WORD_SEPARATORS));
     }
 
     private static void assert_toTitleCaseOfKeyLabel(final Locale locale,

--- a/tests/src/org/futo/inputmethod/latin/common/StringUtilsTests.java
+++ b/tests/src/org/futo/inputmethod/latin/common/StringUtilsTests.java
@@ -35,6 +35,26 @@ public class StringUtilsTests {
     private static final Locale GERMAN = Locale.GERMAN;
     private static final Locale TURKEY = new Locale("tr", "TR");
     private static final Locale GREECE = new Locale("el", "GR");
+    private static final int[] WORD_SEPARATORS = StringUtils.toSortedCodePointArray(" .,!");
+
+    private static void assertWordRange(final String before, final String after,
+            final int expectedStart, final int expectedEnd) {
+        final int[] range = StringUtils.getWordRangeAtCursor(before, after, WORD_SEPARATORS);
+        assertEquals(expectedStart, range[0]);
+        assertEquals(expectedEnd, range[1]);
+    }
+
+    @Test
+    public void testGetWordRangeAtCursor() {
+        assertWordRange("hello", "", 0, 0);
+        assertWordRange("hel", "lo world", 0, 2);
+        assertWordRange("hello ", "world", 6, 5);
+        assertWordRange("", "café!", 0, 4);
+        assertWordRange("go😀", "!", 0, 0);
+        assertEquals(null, StringUtils.getWordRangeAtCursor("hello ", ". world",
+                WORD_SEPARATORS));
+        assertEquals(null, StringUtils.getWordRangeAtCursor("hello ", "", WORD_SEPARATORS));
+    }
 
     private static void assert_toTitleCaseOfKeyLabel(final Locale locale,
             final String lowerCase, final String expected) {


### PR DESCRIPTION
## Summary
- recapitalize the word at or adjacent to the cursor when Shift is pressed without a selection
- retain the existing selected-text recapitalization cycle
- preserve the input-start safety guard for selected-text recapitalization while validating the cursor-only path directly
- accept a recapitalized word before Space or punctuation is inserted, preventing both stale auto-correction and replacement of the recapitalization selection
- add coverage for word boundaries, Unicode, repeated Shift cycling followed by Space, and punctuation/whitespace no-op cases

Fixes #1587

## Validation
- `git diff --check`
- Android APK build and release completed successfully in the related custom integration build: https://github.com/djurcola/android-keyboard/actions/runs/31008152288
- Device regression test pending upstream review/build: type `tgis`, press Shift once or twice, then Space; the selected casing must remain and the separator must be inserted after it.