### PR TITLE
Add suggested words to the user dictionary

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -182,9 +182,14 @@
     <string name="autoupdater_perform_update">Update</string>
 
     <!-- These strings can appear in the keyboard itself -->
+    <string name="keyboard_suggest_manage_word_body">Manage the word \"<xliff:g name="wordToManage" example="crane">%s</xliff:g>\"</string>
     <string name="keyboard_suggest_blacklist_body">Blacklist the word \"<xliff:g name="wordToBlacklist" example="crane">%s</xliff:g>\" from being suggested?</string>
     <!-- Must be fairly short -->
+    <string name="keyboard_suggest_add_to_dictionary">Add to dictionary</string>
+    <!-- Must be fairly short -->
     <string name="keyboard_suggest_add_word_to_blacklist">Blacklist</string>
+    <string name="keyboard_suggest_added_to_dictionary">Added to dictionary</string>
+    <string name="keyboard_suggest_already_in_dictionary">Already in dictionary</string>
     <!-- Must be fairly short -->
     <string name="keyboard_suggest_disable_emojis">Disable emoji suggestions</string>
     <!-- Must be fairly short -->

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -9,7 +9,9 @@ import android.graphics.Color
 import android.inputmethodservice.InputMethodService
 import android.os.Build
 import android.os.Bundle
+import android.provider.UserDictionary
 import android.util.Log
+import android.widget.Toast
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
@@ -56,6 +58,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.futo.inputmethod.accessibility.AccessibilityUtils
+import org.futo.inputmethod.compat.UserDictionaryCompatUtils
 import org.futo.inputmethod.engine.ExpandableSuggestionBarConfiguration
 import org.futo.inputmethod.engine.IMEManager
 import org.futo.inputmethod.engine.general.WordLearner
@@ -835,6 +838,41 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
 
     fun requestForgetWord(suggestedWordInfo: SuggestedWordInfo) {
         uixManager.requestForgetWord(suggestedWordInfo)
+    }
+
+    fun addSuggestedWordToDictionary(suggestedWordInfo: SuggestedWordInfo) = lifecycleScope.launch {
+        val word = suggestedWordInfo.mWord
+        val settings = Settings.getInstance().current
+        val locale = settings.mLocale
+        val wasAdded = withContext(Dispatchers.Default) {
+            val selection = "${UserDictionary.Words.WORD}=? AND ${UserDictionary.Words.LOCALE}=?" +
+                " AND (${UserDictionary.Words.SHORTCUT} is null OR ${UserDictionary.Words.SHORTCUT}='')"
+            val alreadyPresent = contentResolver.query(
+                UserDictionary.Words.CONTENT_URI,
+                arrayOf(UserDictionary.Words.WORD),
+                selection,
+                arrayOf(word, locale.toString()),
+                null
+            )?.use { it.moveToFirst() } == true
+
+            if (!alreadyPresent) {
+                UserDictionaryCompatUtils.addWord(this@LatinIME, word, 250, null, locale)
+            }
+
+            !alreadyPresent
+        }
+
+        if (wasAdded) {
+            imeManager.getActiveIME(settings).requestSuggestionRefresh()
+        }
+        Toast.makeText(
+            this@LatinIME,
+            getString(
+                if (wasAdded) R.string.keyboard_suggest_added_to_dictionary
+                else R.string.keyboard_suggest_already_in_dictionary
+            ),
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     fun blacklistWord(suggestedWordInfo: SuggestedWordInfo?) = lifecycleScope.launch {

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -1503,23 +1503,34 @@ class UixManager(private val latinIME: LatinIME) {
     }
 
     fun requestForgetWord(suggestedWordInfo: SuggestedWords.SuggestedWordInfo) {
+        val isEmojiSuggestion = suggestedWordInfo.mKindAndFlags == SuggestedWordInfo.KIND_EMOJI_SUGGESTION
         keyboardManagerForAction.requestDialog(
-            latinIME.getString(R.string.keyboard_suggest_blacklist_body, suggestedWordInfo.mWord),
-            listOf(
-                DialogRequestItem(latinIME.getString(R.string.cancel)) { },
-                DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_add_word_to_blacklist)) {
-                    latinIME.blacklistWord(suggestedWordInfo)
-                },
-            ) + if(suggestedWordInfo.mKindAndFlags == SuggestedWordInfo.KIND_EMOJI_SUGGESTION) {
-                listOf(
-                    DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_disable_emojis)) {
-                        runBlocking { latinIME.setSetting(SHOW_EMOJI_SUGGESTIONS, false) }
-                        latinIME.blacklistWord(null)
-                    }
-                )
-            } else {
-                listOf()
-            }
+            latinIME.getString(
+                if (isEmojiSuggestion) R.string.keyboard_suggest_blacklist_body
+                else R.string.keyboard_suggest_manage_word_body,
+                suggestedWordInfo.mWord
+            ),
+            listOf(DialogRequestItem(latinIME.getString(R.string.cancel)) { }) +
+                if (isEmojiSuggestion) {
+                    listOf(
+                        DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_add_word_to_blacklist)) {
+                            latinIME.blacklistWord(suggestedWordInfo)
+                        },
+                        DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_disable_emojis)) {
+                            runBlocking { latinIME.setSetting(SHOW_EMOJI_SUGGESTIONS, false) }
+                            latinIME.blacklistWord(null)
+                        }
+                    )
+                } else {
+                    listOf(
+                        DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_add_to_dictionary)) {
+                            latinIME.addSuggestedWordToDictionary(suggestedWordInfo)
+                        },
+                        DialogRequestItem(latinIME.getString(R.string.keyboard_suggest_add_word_to_blacklist)) {
+                            latinIME.blacklistWord(suggestedWordInfo)
+                        }
+                    )
+                }
         ) { }
 
         val v = latinIME.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?


### PR DESCRIPTION
## Summary

Adds **Add to dictionary** to the long-press menu for normal suggested words.

- Uses the existing Android `UserDictionary` integration for the active locale.
- Avoids duplicate no-shortcut entries and refreshes active suggestions after insertion.
- Keeps **Blacklist** available for normal suggestions.
- Preserves the existing emoji menu: **Blacklist** and **Disable emoji suggestions** only.

## Screenshot

Normal suggested-word long press on device:

![Long-press menu with Add to dictionary](https://raw.githubusercontent.com/djurcola/android-keyboard/agent/pr-media-add-dictionary-screenshot/pr-media/add-to-dictionary.jpg)

## Validation

- `git diff --check` passed.
- Resource XML parses successfully.
- The behavior was exercised in the downstream implementation on a physical Android device.
- Local Gradle unit testing is blocked before compilation in this environment because no Android SDK is configured; upstream CI is expected to provide the Android build validation.

The screenshot is hosted on a dedicated media-only branch of the contributor fork and is not part of this PR's code diff.
