### PR TITLE
Make backspace after swipe word deletion configurable

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -544,6 +544,8 @@
 
     <string name="swipe_settings_sensitive_swipe">Increase sensitivity</string>
     <string name="swipe_settings_sensitive_swipe_subtitle">Make swipe trigger more often</string>
+    <string name="swipe_settings_backspace_delete_word">Delete whole word with backspace</string>
+    <string name="swipe_settings_backspace_delete_word_subtitle">After swipe typing, backspace deletes the whole word</string>
 
     <string name="swipe_settings_kasroz">KASROZ</string>
     <string name="swipe_settings_kasroz_subtitle">The best keyboard layout to swipe</string>

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -1445,7 +1445,7 @@ public final class InputLogic {
                 && inputTransaction.mSettingsValues.mBackspaceModeHold == Settings.BACKSPACE_MODE_WORDS;
 
         if (mWordComposer.isComposingWord() && !mConnection.hasSelection()) {
-            if (mWordComposer.isBatchMode()) {
+            if (mWordComposer.isBatchMode() && inputTransaction.mSettingsValues.mBackspaceDeletesSwipeWord) {
                 final String rejectedSuggestion = mWordComposer.getTypedWord();
                 mWordComposer.reset(true);
                 mWordComposer.setRejectedBatchModeSuggestion(rejectedSuggestion);
@@ -1463,6 +1463,11 @@ public final class InputLogic {
                 }
             } else {
                 mWordComposer.applyProcessedEvent(event);
+                // Exit batch mode after the first backspace
+                if (mWordComposer.isBatchMode()) {
+                    final int[] codePoints = StringUtils.toCodePointArray(mWordComposer.getTypedWord());
+                    mWordComposer.setComposingWord(codePoints, mImeHelper.getCodepointCoordinates(codePoints));
+                }
                 StatsUtils.onBackspacePressed(1);
             }
             if (mWordComposer.isComposingWord()) {

--- a/java/src/org/futo/inputmethod/latin/settings/Settings.java
+++ b/java/src/org/futo/inputmethod/latin/settings/Settings.java
@@ -125,6 +125,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
             "pref_backspace_delete_inserted_text";
     public static final String PREF_BACKSPACE_UNDO_AUTOCORRECT =
             "pref_backspace_undo_autocorrect";
+    public static final String PREF_BACKSPACE_DELETE_SWIPE_WORD =
+            "pref_backspace_delete_swipe_word";
 
     public static final String PREF_SPACEBAR_MODE_LEGACY = "pref_spacebar_mode";
     public static final int SPACEBAR_MODE_SWIPE_CURSOR_LEGACY = 0; // Long-Press switches language, swipe moves cursor

--- a/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/org/futo/inputmethod/latin/settings/SettingsValues.java
@@ -106,6 +106,7 @@ public class SettingsValues {
 
     public final boolean mBackspaceDeletesInsertedText;
     public final boolean mBackspaceUndoesAutocorrect;
+    public final boolean mBackspaceDeletesSwipeWord;
     public final int mSpacebarSwipeMode;
     public final int mSpacebarHoldMode;
     public final int mBackspaceMode;
@@ -203,6 +204,7 @@ public class SettingsValues {
 
         mBackspaceDeletesInsertedText = prefs.getBoolean(Settings.PREF_BACKSPACE_DELETE_INSERTED_TEXT, true);
         mBackspaceUndoesAutocorrect = prefs.getBoolean(Settings.PREF_BACKSPACE_UNDO_AUTOCORRECT, true);
+        mBackspaceDeletesSwipeWord = prefs.getBoolean(Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD, true);
 
         int legacySpacebarMode = prefs.getInt(Settings.PREF_SPACEBAR_MODE_LEGACY, Settings.SPACEBAR_MODE_SWIPE_CURSOR_LEGACY);
         mSpacebarSwipeMode = prefs.getInt(Settings.PREF_SPACEBAR_SWIPE_MODE,

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Swipe.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Swipe.kt
@@ -232,6 +232,13 @@ val SwipeMenu = UserSettingsMenu(
             default = {false},
         ),
 
+        userSettingToggleSharedPrefs(
+            title = R.string.swipe_settings_backspace_delete_word,
+            subtitle = R.string.swipe_settings_backspace_delete_word_subtitle,
+            key = Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD,
+            default = {true},
+        ),
+
         // KASROZ is primarily for English and the menu isn't translated, so it's hidden if user
         // doesn't have English layout
         UserSetting(R.string.swipe_settings_kasroz, subtitle = R.string.swipe_settings_kasroz_subtitle, visibilityCheck = {

--- a/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
+++ b/tests/src/org/futo/inputmethod/latin/InputLogicTests.java
@@ -30,16 +30,19 @@ import org.futo.inputmethod.latin.settings.Settings;
 public class InputLogicTests extends InputTestsBase {
 
     private boolean mNextWordPrediction;
+    private boolean mBackspaceDeletesSwipeWord;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         mNextWordPrediction = getBooleanPreference(Settings.PREF_BIGRAM_PREDICTIONS, true);
+        mBackspaceDeletesSwipeWord = getBooleanPreference(Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD, true);
     }
 
     @Override
     public void tearDown() throws Exception {
         setBooleanPreference(Settings.PREF_BIGRAM_PREDICTIONS, mNextWordPrediction, true);
+        setBooleanPreference(Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD, mBackspaceDeletesSwipeWord, true);
         super.tearDown();
     }
 
@@ -666,6 +669,25 @@ public class InputLogicTests extends InputTestsBase {
         } else {
             assertEquals("this", mEditText.getText().toString());
         }
+    }
+
+    public void testGestureBackspaceDeletesLastCharacterWhenConfigured() {
+        setBooleanPreference(Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD, false, true);
+        gesture("this");
+        type(Constants.CODE_DELETE);
+        assertEquals("gesture then backspace deletes one character", "thi", mEditText.getText().toString());
+    }
+
+    public void testGestureManualSuggestionSelectionWhenBackspaceModeConfigured() {
+        setBooleanPreference(Settings.PREF_BACKSPACE_DELETE_SWIPE_WORD, false, true);
+        gesture("this");
+        sleep(DELAY_TO_WAIT_FOR_PREDICTIONS_MILLIS);
+        runMessages();
+        final SuggestedWords suggestedWords = mLatinIMELegacy.getSuggestedWordsForTest();
+        assertTrue("gesture should provide an alternative suggestion", suggestedWords.size() > 1);
+        final String alternative = suggestedWords.getWord(1);
+        pickSuggestionManually(alternative);
+        assertEquals("manual suggestion selection after gesture", alternative, mEditText.getText().toString());
     }
 
     private void typeOrGestureWordAndPutCursorInside(final boolean gesture, final String word,


### PR DESCRIPTION
With the current behaviour, when backspace is pressed after a swipe, the whole word just inserted by the swipe is deleted.
For languages like Italian, this makes the keyboard almost unusable, since the last 1 to 3 letters change completely the meaning of a word, and of a sentence if not corrected. Confirming the word and hitting backspace twice for every word adds a lot of extra typing (not considering that I'm used to have this feature from Ms SwiftKey, and I've been deleting a lot of words by mistake since I started using Futo Keyboard).

This PR adds an option to disable the word deletion when backspace is hit after a swipe, and instead delete the last character and exit batch mode.

Note: This feature was requested in #1368, that was closed as not planned. I'm proposing this PR anyway, since this is, in my opinion, a big usability problem.

AI Disclosure: I have no familiarity with the code base and a limited experience with java, therefore I used AI to navigate and understand the code, figure out how to exit batch mode after the first backspace, review the patch and to write the unit tests (I personally reviewed these afterwards).
